### PR TITLE
Mongodb relations simplification

### DIFF
--- a/packages/core/v-api/middle.zod-validate.js
+++ b/packages/core/v-api/middle.zod-validate.js
@@ -12,7 +12,7 @@ export const assert_zod = (zod_schema, item) => {
     /** @type {import("zod").SafeParseError<any>} */
     const casted = result;
 
-    console.log(JSON.stringify(casted.error?.issues, null, 2))
+    // console.log(JSON.stringify(casted.error?.issues, null, 2))
 
     throw new StorecraftError(casted.error?.issues, 400);
   };

--- a/packages/core/v-api/utils.func.js
+++ b/packages/core/v-api/utils.func.js
@@ -8,9 +8,10 @@ export class StorecraftError extends Error {
    */
   constructor(message, code=400) {
     super(JSON.stringify(message, null, 2));
+
     this.code = code;
     this.message = message;
-    // console.log(JSON.stringify(message, null, 2));
+    console.log(JSON.stringify(message, null, 2));
   }
 }
 

--- a/packages/database-mongodb-node/driver.js
+++ b/packages/database-mongodb-node/driver.js
@@ -39,6 +39,8 @@ const connect = async (uri, options) => {
 
 /**
  * @typedef {import('@storecraft/core/v-database').db_driver} db_driver
+ * 
+ * 
  * @implements {db_driver}
  */
 export class MongoDB {

--- a/packages/database-mongodb-node/src/con.auth_users.js
+++ b/packages/database-mongodb-node/src/con.auth_users.js
@@ -1,7 +1,9 @@
 import { MongoDB } from '../driver.js'
 import { Collection } from 'mongodb'
 import { sanitize_one, to_objid } from './utils.funcs.js'
-import { count_regular, get_regular, list_regular, upsert_regular } from './con.shared.js'
+import { 
+  count_regular, get_regular, list_regular, upsert_regular 
+} from './con.shared.js'
 
 /**
  * @typedef {import('@storecraft/core/v-database').db_auth_users} db_col

--- a/packages/database-mongodb-node/src/con.auth_users.js
+++ b/packages/database-mongodb-node/src/con.auth_users.js
@@ -9,6 +9,8 @@ import { count_regular, get_regular, list_regular, upsert_regular } from './con.
 
 /**
  * @param {MongoDB} d 
+ * 
+ * 
  * @returns {Collection<db_col["$type_get"]>}
  */
 const col = (d) => d.collection('auth_users');
@@ -20,12 +22,16 @@ const upsert = (driver) => upsert_regular(driver, col(driver));
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["get"]}
  */
 const get = (driver) => get_regular(driver, col(driver));
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["getByEmail"]}
  */
 const getByEmail = (driver) => {
@@ -43,6 +49,8 @@ const getByEmail = (driver) => {
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["remove"]}
  */
 const remove = (driver) => {
@@ -57,6 +65,8 @@ const remove = (driver) => {
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["removeByEmail"]}
  */
 const removeByEmail = (driver) => {
@@ -82,6 +92,8 @@ const count = (driver) => count_regular(driver, col(driver));
 
 /** 
  * @param {MongoDB} driver
+ * 
+ * 
  * @return {db_col & { _col: ReturnType<col>}}
  * */
 export const impl = (driver) => {

--- a/packages/database-mongodb-node/src/con.customers.js
+++ b/packages/database-mongodb-node/src/con.customers.js
@@ -11,6 +11,8 @@ import { query_to_mongo } from './utils.query.js';
 
 /**
  * @param {MongoDB} d 
+ * 
+ * 
  * @returns {Collection<db_col["$type_get"]>}
  */
 const col = (d) => d.collection('customers');
@@ -27,6 +29,8 @@ const get = (driver) => get_regular(driver, col(driver));
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["getByEmail"]}
  */
 const getByEmail = (driver) => {
@@ -40,6 +44,8 @@ const getByEmail = (driver) => {
 /**
  * 
  * @param {string} email_or_id 
+ * 
+ * 
  * @returns { {_id:ObjectId} | {email: string}}
  */
 export const email_or_id = (email_or_id) => {
@@ -54,6 +60,8 @@ export const email_or_id = (email_or_id) => {
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["remove"]}
  */
 const remove = (driver) => {
@@ -101,6 +109,8 @@ const count = (driver) => count_regular(driver, col(driver));
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["list_customer_orders"]}
  */
 const list_customer_orders = (driver) => {
@@ -136,10 +146,12 @@ const list_customer_orders = (driver) => {
 
 /** 
  * @param {MongoDB} driver
+ * 
+ * 
  * @return {db_col & { _col: ReturnType<col>}}
  * */
 export const impl = (driver) => {
-  driver
+
   return {
     _col: col(driver),
     get: get(driver),

--- a/packages/database-mongodb-node/src/con.discounts.utils.js
+++ b/packages/database-mongodb-node/src/con.discounts.utils.js
@@ -18,6 +18,8 @@ const extract_abs_number = v => {
 /**
  * create a mongodb conjunctions clauses from discount, intended
  * for filtering.
+ * 
+ * 
  * @param {import("@storecraft/core/v-api").DiscountType} d 
  */
 export const discount_to_mongo_conjunctions = d => {

--- a/packages/database-mongodb-node/src/con.images.js
+++ b/packages/database-mongodb-node/src/con.images.js
@@ -28,6 +28,8 @@ const get = (driver) => get_regular(driver, col(driver));
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["remove"]}
  */
 const remove = (driver) => {
@@ -78,7 +80,11 @@ const remove = (driver) => {
 
 /**
  * report media usages
+ * 
+ * 
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["report_document_media"]}
  */
 export const report_document_media = (driver) => {
@@ -94,7 +100,11 @@ export const report_document_media = (driver) => {
     
     /** 
      * @param {string} url 
-     * @returns {import('mongodb').AnyBulkWriteOperation<import('@storecraft/core/v-api').ImageType>}
+     * 
+     * 
+     * @returns {import('mongodb').AnyBulkWriteOperation<
+     *  import('@storecraft/core/v-api').ImageType>
+     * }
      */
     const url_to_update = url => {
       const id_on_insert = ID('img');
@@ -142,6 +152,8 @@ const count = (driver) => count_regular(driver, col(driver));
 
 /** 
  * @param {MongoDB} driver
+ * 
+ * 
  * @return {db_col & { _col: ReturnType<col>}}
  * */
 export const impl = (driver) => {

--- a/packages/database-mongodb-node/src/con.notifications.js
+++ b/packages/database-mongodb-node/src/con.notifications.js
@@ -10,6 +10,8 @@ import { to_objid } from './utils.funcs.js';
 
 /**
  * @param {MongoDB} d 
+ * 
+ * 
  * @returns {Collection<db_col["$type_get"]>}
  */
 const col = (d) => d.collection('notifications');
@@ -21,6 +23,8 @@ const upsert = (driver) => upsert_regular(driver, col(driver));
 
 /**
  * @param {MongoDB} driver 
+ * 
+ * 
  * @returns {db_col["upsertBulk"]}
  */
 const upsertBulk = (driver) => {
@@ -61,10 +65,12 @@ const count = (driver) => count_regular(driver, col(driver));
 
 /** 
  * @param {MongoDB} driver
+ * 
+ * 
  * @return {db_col & { _col: ReturnType<col>}}
- * */
+ */
 export const impl = (driver) => {
-  driver
+  
   return {
     _col: col(driver),
     get: get(driver),

--- a/packages/database-mongodb-node/src/con.orders.js
+++ b/packages/database-mongodb-node/src/con.orders.js
@@ -9,6 +9,8 @@ import { count_regular, get_regular, list_regular,
 
 /**
  * @param {MongoDB} d 
+ * 
+ * 
  * @returns {Collection<db_col["$type_get"]>}
  */
 const col = (d) => d.collection('orders');
@@ -42,10 +44,12 @@ const count = (driver) => count_regular(driver, col(driver));
 
 /** 
  * @param {MongoDB} driver
+ * 
+ * 
  * @return {db_col & { _col: ReturnType<col>}}
- * */
+ */
 export const impl = (driver) => {
-  driver
+
   return {
     _col: col(driver),
     get: get(driver),

--- a/packages/database-mongodb-node/src/con.posts.js
+++ b/packages/database-mongodb-node/src/con.posts.js
@@ -49,25 +49,14 @@ const upsert = (driver) => {
             driver, 'storefronts', 'posts', objid, data, session
           );
 
-          // await driver.resources.storefronts._col.updateMany(
-          //   { '_relations.posts.ids' : objid },
-          //   { $set: { [`_relations.posts.entries.${objid.toString()}`]: data } },
-          //   { session }
-          // );
-
           ////
           // REPORT IMAGES USAGE
           ////
           await report_document_media(driver)(data, session);
 
           // SAVE ME
-
           await save_me(driver, 'posts', objid, data, session);
-          // const res = await col(driver).replaceOne(
-          //   { _id: objid }, 
-          //   data, 
-          //   { session, upsert: true }
-          // );
+
         }
       );
     } catch(e) {
@@ -111,24 +100,10 @@ const remove = (driver) => {
             driver, 'storefronts', 'posts', objid, session
           );
 
-          // await driver.resources.storefronts._col.updateMany(
-          //   { '_relations.posts.ids' : objid },
-          //   { 
-          //     $pull: { '_relations.posts.ids': objid, },
-          //     $unset: { [`_relations.posts.entries.${objid.toString()}`]: '' },
-          //   },
-          //   { upsert: false, session }
-          // );
-
           // DELETE ME
           await delete_me(
             driver, 'posts', objid, session
           );
-
-          // const res = await col(driver).deleteOne( 
-          //   { _id: objid },
-          //   { session }
-          // );
 
         }
       );

--- a/packages/database-mongodb-node/src/con.products.js
+++ b/packages/database-mongodb-node/src/con.products.js
@@ -163,6 +163,7 @@ const upsert = (driver) => {
       );
     } catch (e) {
       console.log(e);
+      
       return false;
     } finally {
       await session.endSession();

--- a/packages/database-mongodb-node/src/con.shipping.js
+++ b/packages/database-mongodb-node/src/con.shipping.js
@@ -48,14 +48,6 @@ const upsert = (driver) => {
             driver, 'storefronts', 'shipping_methods', objid, data, session
           );
 
-          // await driver.resources.storefronts._col.updateMany(
-          //   { '_relations.shipping_methods.ids' : objid },
-          //   { $set: { [`_relations.shipping_methods.entries.${objid.toString()}`]: data } },
-          //   { session }
-          // );
-
-          // console.log('search_terms', search_terms)
-
           ////
           // REPORT IMAGES USAGE
           ////
@@ -65,12 +57,6 @@ const upsert = (driver) => {
           await save_me(
             driver, 'shipping_methods', objid, data, session
           );
-
-          // const res = await col(driver).replaceOne(
-          //   { _id: objid }, 
-          //   data, 
-          //   { session, upsert: true }
-          // );
 
         }
       );
@@ -116,24 +102,11 @@ const remove = (driver) => {
             driver, 'storefronts', 'shipping_methods', objid, session
           );
 
-          // await driver.resources.storefronts._col.updateMany(
-          //   { '_relations.shipping_methods.ids' : objid },
-          //   { 
-          //     $pull: { '_relations.shipping_methods.ids': objid },
-          //     $unset: { [`_relations.shipping_methods.entries.${objid.toString()}`]: '' },
-          //   },
-          //   { session }
-          // );
-
           // DELETE ME
           await delete_me(
             driver, 'shipping_methods', objid, session
           );
 
-          // const res = await col(driver).deleteOne( 
-          //   { _id: objid }, 
-          //   { session }
-          // );
         }
       );
     } catch(e) {

--- a/packages/database-mongodb-node/src/con.storefronts.js
+++ b/packages/database-mongodb-node/src/con.storefronts.js
@@ -16,7 +16,10 @@ import { report_document_media } from './con.images.js';
  * @param {MongoDB} d 
  * 
  * 
- * @returns {Collection<import('./utils.relations.js').WithRelations<db_col["$type_get"]>>}
+ * @returns {Collection<
+ *  import('./utils.relations.js').WithRelations<db_col["$type_get"]>>
+ * }
+ * 
  */
 const col = (d) => d.collection('storefronts');
 
@@ -66,12 +69,6 @@ const upsert = (driver) => {
           await save_me(
             driver, 'storefronts', to_objid(data.id), replacement, session
           );
-
-          // const res = await col(driver).replaceOne(
-          //   { _id: to_objid(data.id) }, 
-          //   replacement, 
-          //   { session, upsert: true }
-          // );
 
         }
       );

--- a/packages/database-mongodb-node/src/con.tags.js
+++ b/packages/database-mongodb-node/src/con.tags.js
@@ -10,6 +10,8 @@ import { count_regular, get_regular, list_regular,
 
 /**
  * @param {MongoDB} d 
+ * 
+ * 
  * @returns {Collection<db_col["$type_get"]>}
  */
 const col = (d) => d.collection('tags');
@@ -41,6 +43,8 @@ const count = (driver) => count_regular(driver, col(driver));
 
 /** 
  * @param {MongoDB} driver
+ * 
+ * 
  * @return {db_col & { _col: ReturnType<col>}}
  * */
 export const impl = (driver) => {

--- a/packages/database-mongodb-node/src/utils.funcs.js
+++ b/packages/database-mongodb-node/src/utils.funcs.js
@@ -1,31 +1,45 @@
 import { ObjectId } from 'mongodb';
 
+/** @param {any} v */
 export const isDef = v => v!==undefined && v!==null;
+
+/** @param {any} v */
 export const isUndef = v => !isDef(v);
 
 /**
  * 
  * @param  {...any} keys 
- * @returns 
  */
 export const delete_keys = (...keys) => {
 
   /**
    * @template T
+   * 
+   * 
    * @param {T} o
+   * 
+   * 
    * @returns {T}
    */
   return (o) => {
-    keys.forEach(k => {o?.[k] && delete o[k]} )
+    keys.forEach(k => {o?.[k] && delete o[k]});
+
     return o
   }
 }
 
 /**
  * Sanitize hidden properties in-place
+ * 
+ * 
  * @template {object} T
+ * 
+ * 
  * @param {T} o 
+ * 
+ * 
  * @return {Omit<T, '_id' | '_relations'>}
+ * 
  */
 export const sanitize_hidden = o => {
   if(!isDef(o))
@@ -39,8 +53,13 @@ export const sanitize_hidden = o => {
 }
 
 /**
+ * 
  * @template T
+ * 
+ * 
  * @param {T} o 
+ * 
+ * 
  * @returns {T}
  */
 export const delete_id = o => {
@@ -48,8 +67,12 @@ export const delete_id = o => {
 }
 
 /**
+ * 
  * Sanitize the mongo document before sending to client
+ * 
  * @template T
+ * 
+ * 
  * @param {T} o 
  */
 export const sanitize_one = o => {
@@ -58,8 +81,12 @@ export const sanitize_one = o => {
 
 /**
  * Sanitize the mongo document before sending to client
+ * 
  * @template T
+ * 
+ * 
  * @param {T[]} o 
+ * 
  */
 export const sanitize_array = o => {
   return o?.map(it => sanitize_hidden(it));
@@ -68,22 +95,26 @@ export const sanitize_array = o => {
 /**
  * 
  * @param {string} id 
- * @returns 
+ * 
  */
 export const to_objid = id => new ObjectId(id.split('_').at(-1))
 
 /**
  * 
  * @param {string} handle_or_id 
- * @returns { {_id:ObjectId} | {handle: string}}
+ * 
+ * 
+ * @returns { { _id:ObjectId } | { handle: string }}
  */
 export const handle_or_id = (handle_or_id) => {
   let r = {};
+
   try {
     r._id = to_objid(handle_or_id);
   } catch (e) {
     r.handle = handle_or_id;
   }
+
   return r;
 }
 

--- a/packages/database-mongodb-node/src/utils.query.js
+++ b/packages/database-mongodb-node/src/utils.query.js
@@ -15,9 +15,12 @@ let a = {
  * 3. (a1, a2, a3) >  (b1, b2, b3) ==> (a1 > b1) || (a1=b1 & a2>b2) || (a1=b1 & a2=b2 & a3>b3)
  * 4. (a1, a2, a3) >= (b1, b2, b3) ==> (a1 > b1) || (a1=b1 & a2>b2) || (a1=b1 & a2=b2 & a3>=b3)
  * 
+ * 
  * @param {import("@storecraft/core/v-api").Cursor} c 
  * @param {'>' | '>=' | '<' | '<='} relation 
- * @param {(x: [k: string, v: any]) => [k: string, v: any]} transformer Your chance to change key and value
+ * @param {(x: [k: string, v: any]) => [k: string, v: any]} transformer 
+ * Your chance to change key and value
+ * 
  */
 export const query_cursor_to_mongo = (c, relation, transformer=(x)=>x) => {
 
@@ -110,7 +113,11 @@ export const query_vql_to_mongo = root => {
 
 /**
  * Let's transform ids into mongo ids
+ * 
+ * 
  * @param {import("@storecraft/core/v-api").Tuple<string>} c a cursor record
+ * 
+ * 
  * @returns {[k: string, v: any]}
  */
 const transform = c => {
@@ -121,6 +128,8 @@ const transform = c => {
 
 /**
  * Convert an API Query into mongo dialect, also sanitize.
+ * 
+ * 
  * @param {import("@storecraft/core/v-api").ApiQuery} q 
  */
 export const query_to_mongo = (q) => {

--- a/packages/database-mongodb-node/src/utils.relations.js
+++ b/packages/database-mongodb-node/src/utils.relations.js
@@ -133,7 +133,7 @@ export const add_search_terms_relation_on = (data, terms=[]) => {
  */
 export const update_entry_on_all_connection_of_relation = (
   driver, collection, relation_name, entry_objid, entry, session,
-  search_terms_to_add
+  search_terms_to_add=[]
 ) => {
 
   return driver.collection(collection).updateMany(
@@ -178,7 +178,7 @@ export const update_entry_on_all_connection_of_relation = (
  */
 export const update_specific_connection_of_relation_with_filter = (
   driver, collection, relation_name, from_object_filter, 
-  entry_objid, entry, session, search_terms_to_add
+  entry_objid, entry, session, search_terms_to_add=[]
 ) => {
 
   return driver.collection(collection).updateOne(
@@ -220,7 +220,7 @@ export const update_specific_connection_of_relation_with_filter = (
  */
 export const update_specific_connection_of_relation = (
   driver, collection, relation_name, from_objid, entry_objid, 
-  entry, session, search_terms_to_add
+  entry, session, search_terms_to_add=[]
 ) => {
 
   return update_specific_connection_of_relation_with_filter(
@@ -295,7 +295,7 @@ export const remove_entry_from_all_connection_of_relation = (
  */
 export const remove_specific_connection_of_relation = (
   driver, collection, relation_name, from_objid, entry_objid, session,
-  search_terms_to_remove
+  search_terms_to_remove=[]
 ) => {
 
   return remove_specific_connection_of_relation_with_filter(

--- a/packages/sdk/src/utils.api.fetch.js
+++ b/packages/sdk/src/utils.api.fetch.js
@@ -1,5 +1,7 @@
 
-import { api_query_to_searchparams } from '@storecraft/core/v-api/utils.query.js';
+import { 
+  api_query_to_searchparams 
+} from '@storecraft/core/v-api/utils.query.js';
 import { assert } from './utils.functional.js';
 
 /**


### PR DESCRIPTION
In this `PR`, I youch upon a much needed refactor for `mongodb-node` package:
- Simplifying the relations code
- Refactoring common methods and utilities
- Code is easier to understand and follow