### PR TITLE
Core vapi interface

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,6 +1,6 @@
 import { STATUS_CODES } from './v-polka/codes.js';
 import { create_rest_api } from './v-rest/index.js';
-import * as api from './v-api/index.js'
+import { create_api } from './v-api/index.js'
 export * from './v-api/types.api.enums.js'
 
 /** 
@@ -83,6 +83,13 @@ export class App {
   #_config;
 
   /** 
+   * @description The API logic
+   * 
+   * @type {ReturnType<create_api>} 
+   */ 
+  #_api;
+  
+  /** 
    * @description The REST API controller
    * 
    * @type {ReturnType<create_rest_api>} 
@@ -119,7 +126,7 @@ export class App {
     this.#_extensions = extensions;
     this.#_config = config;
     this.#_is_ready = false;
-  }
+  } 
 
   /**
    * 
@@ -178,6 +185,7 @@ export class App {
       console.log(e)
     }
 
+    this.#_api = create_api(this);
     this.#_rest_controller = create_rest_api(this);
     this.#_is_ready = true;
     
@@ -197,7 +205,7 @@ export class App {
    * @description Get the main **API** logic 
    */
   get api() {
-    return api
+    return this.#_api;
   }
 
   /** 

--- a/packages/core/v-api/con.auth.logic.js
+++ b/packages/core/v-api/con.auth.logic.js
@@ -14,7 +14,7 @@ import { isDef } from './utils.index.js'
  * 
  * @param {App} app 
  */  
-export const removeByEmail = async (app) => 
+export const removeByEmail = (app) => 
 /**
  * 
  * @param {string} email

--- a/packages/core/v-api/con.auth.logic.js
+++ b/packages/core/v-api/con.auth.logic.js
@@ -9,21 +9,17 @@ import { decode, encode, fromUint8Array } from '../v-crypto/base64.js'
 import { isDef } from './utils.index.js'
 
 
-/**
- * 
- * @param {App} app 
- * @param {string} id
- */  
-export const removeById = async (app, id) => {
-  return app.db.resources.auth_users.remove(id);
-}
 
 /**
  * 
  * @param {App} app 
- * @param {string} email
  */  
-export const removeByEmail = async (app, email) => {
+export const removeByEmail = async (app) => 
+/**
+ * 
+ * @param {string} email
+ */
+(email) => {
   return app.db.resources.auth_users.removeByEmail(email);
 }
 
@@ -39,12 +35,16 @@ const isAdminEmail = (app, email) => {
 /**
  * 
  * @param {App} app 
+ * 
+ */  
+export const signup = (app) => 
+/**
+ * 
  * @param {import('./types.api.js').ApiAuthSignupType} body 
  * 
- * 
  * @returns {Promise<import('./types.api.js').ApiAuthResult>}
- */  
-export const signup = async (app, body) => {
+ */
+async (body) => {
 
   assert_zod(apiAuthSignupTypeSchema, body);
   
@@ -107,13 +107,17 @@ export const signup = async (app, body) => {
 /**
  * 
  * @param {App} app 
+ */  
+export const signin = (app) => 
+/**
+ * 
  * @param {import('./types.api.js').ApiAuthSigninType} body 
  * @param {boolean} [fail_if_not_admin=false] 
  * 
  * 
  * @returns {Promise<import('./types.api.js').ApiAuthResult>}
- */  
-export const signin = async (app, body, fail_if_not_admin=false) => {
+ */
+async (body, fail_if_not_admin=false) => {
   assert_zod(apiAuthSigninTypeSchema, body);
 
   const { email, password } = body;
@@ -123,7 +127,7 @@ export const signin = async (app, body, fail_if_not_admin=false) => {
   const isAdmin = isAdminEmail(app, email);
   // An admin first login will register the default `admin` password
   if(!existingUser && isAdmin) {
-    await signup(app, { ...body, password: 'admin' });
+    await signup(app)({ ...body, password: 'admin' });
     existingUser = await app.db.resources.auth_users.getByEmail(email);
   }
 
@@ -166,12 +170,15 @@ export const signin = async (app, body, fail_if_not_admin=false) => {
 /**
  * 
  * @param {App} app 
+ */  
+export const refresh = (app) => 
+/**
+ * 
  * @param {import('./types.api.js').ApiAuthRefreshType} body 
  * 
- * 
  * @returns {Promise<import('./types.api.js').ApiAuthResult>}
- */  
-export const refresh = async (app, body) => {
+ */
+async (body) => {
   assert_zod(apiAuthRefreshTypeSchema, body);
 
   const { refresh_token } = body;
@@ -230,11 +237,13 @@ export const create_search_terms = item => {
 /**
  * 
  * @param {App} app 
- * 
+ */  
+export const create_api_key = (app) => 
+/**
  * 
  * @returns {Promise<import('./types.api.js').ApiKeyResult>}
- */  
-export const create_api_key = async (app) => {
+ */
+async () => {
 
   const key = await crypto.subtle.generateKey(
     {
@@ -309,12 +318,15 @@ export const parse_api_key = (body) => {
  * with the database every time.
  * 
  * @param {App} app 
+ */  
+export const verify_api_key = (app) => 
+/**
+ * 
  * @param {import('./types.api.js').ApiKeyResult} body 
  * 
- * 
  * @returns {Promise<import('./types.api.js').AuthUserType>}
- */  
-export const verify_api_key = async (app, body) => {
+ */
+async (body) => {
 
   const {
     email, password
@@ -351,7 +363,8 @@ export const verify_api_key = async (app, body) => {
  * @param {App} app 
  * 
  */  
-export const list_all_api_keys_info = async (app) => {
+export const list_all_api_keys_info = (app) => 
+async () => {
 
   const apikeys = await app.db.resources.auth_users.list(
     {
@@ -375,10 +388,12 @@ export const list_all_api_keys_info = async (app) => {
  * 
  * 
  * @param {App} app 
- * @param {import('./types.api.query.js').ApiQuery} [query={}] 
- * 
  */  
-export const list_auth_users = async (app, query={}) => {
+export const list_auth_users = (app) => 
+/**
+ * @param {import('./types.api.query.js').ApiQuery} [query={}] 
+ */
+async (query={}) => {
 
   const items = await app.db.resources.auth_users.list(
     query
@@ -394,10 +409,13 @@ export const list_auth_users = async (app, query={}) => {
 /**
  * 
  * @param {App} app 
- * @param {string} id_or_email 
- * 
  */  
-export const get_auth_user = (app, id_or_email) => {
+export const get_auth_user = (app) => 
+/**
+ * 
+ * @param {string} id_or_email 
+ */
+async (id_or_email) => {
 
   return app.db.resources.auth_users.get(
     id_or_email
@@ -408,12 +426,37 @@ export const get_auth_user = (app, id_or_email) => {
 /**
  * 
  * @param {App} app 
- * @param {string} id_or_email 
- * 
  */  
-export const remove_auth_user = async (app, id_or_email) => {
+export const remove_auth_user = (app) => 
+/**
+ * 
+ * @param {string} id_or_email 
+ */
+async (id_or_email) => {
 
   await app.db.resources.auth_users.remove(
     id_or_email
   );
+}
+
+/**
+ * 
+ * @param {App} app 
+ */
+export const inter = app => {
+
+  return {
+    signin: signin(app),
+    signup: signup(app),
+    refresh: refresh(app),
+    create_api_key: create_api_key(app),
+    list_all_api_keys_info: list_all_api_keys_info(app),
+    parse_api_key: parse_api_key,
+    verify_api_key: verify_api_key(app),
+    get_auth_user: get_auth_user(app),
+    list_auth_users: list_auth_users(app),
+    remove_auth_user: remove_auth_user(app),
+    removeByEmail: removeByEmail(app),
+  }
+
 }

--- a/packages/core/v-api/con.collections.logic.js
+++ b/packages/core/v-api/con.collections.logic.js
@@ -16,50 +16,56 @@ export const db = app => app.db.resources.collections;
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
-  app, db(app), 'col', collectionTypeUpsertSchema, 
-  (final) => {
-    assert(
-      [final.handle].every(
-        h => to_handle(h)===h
-      ),
-      'Handle is invalid', 400
-    );
-    return [];
-  }
-)(item);
+export const upsert = (app) => 
+  /**
+   * 
+   * @param {ItemTypeUpsert} item
+   */
+  (item) => regular_upsert(
+    app, db(app), 'col', collectionTypeUpsertSchema, 
+    (final) => {
+      assert(
+        [final.handle].every(
+          h => to_handle(h)===h
+        ),
+        'Handle is invalid', 400
+      );
+      return [];
+    }
+  )(item);
 
 
 /**
  * given a collection handle and query, return products of that collection
+ * 
+ * 
  * @param {import("../types.public.js").App} app
- * @param {import('../v-database/types.public.js').HandleOrId} handle_or_id 
- * @param {import('./types.api.query.js').ApiQuery} q 
  */
-export const list_collection_products = async (app, handle_or_id, q) => {
-  return db(app).list_collection_products(handle_or_id, q);
+export const list_collection_products = (app) => 
+  /**
+   * 
+   * @param {import('../v-database/types.public.js').HandleOrId} handle_or_id 
+   * @param {import('./types.api.query.js').ApiQuery} q 
+   */
+  (handle_or_id, q) => {
+    return db(app).list_collection_products(handle_or_id, q);
+  }
+
+
+/**
+ * 
+ * @param {import("../types.public.js").App} app
+ */  
+export const inter = app => {
+
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+    list_collection_products: list_collection_products(app)
+  }
 }
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);

--- a/packages/core/v-api/con.discounts.logic.js
+++ b/packages/core/v-api/con.discounts.logic.js
@@ -17,9 +17,13 @@ export const db = app => app.db.resources.discounts;
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'dis', discountTypeUpsertSchema, 
   (final) => {
     assert(
@@ -40,33 +44,33 @@ export const upsert = (app, item) => regular_upsert(
 
 
 /**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
-
-/**
  * given a discount handle and query, return products of that discount
+ * 
+ * 
  * @param {import("../types.public.js").App} app
+ */
+export const list_discounts_products = (app) => 
+/**
+ * 
  * @param {import('../v-database/types.public.js').HandleOrId} handle_or_id 
  * @param {import('./types.api.query.js').ApiQuery} [q] 
  */
-export const list_discounts_products = async (app, handle_or_id, q) => {
+(handle_or_id, q) => {
   return db(app).list_discount_products(handle_or_id, q);
+}
+
+
+/**
+ * 
+ * @param {import("../types.public.js").App} app
+ */  
+export const inter = app => {
+
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+    list_discounts_products: list_discounts_products(app)
+  }
 }

--- a/packages/core/v-api/con.images.logic.js
+++ b/packages/core/v-api/con.images.logic.js
@@ -13,13 +13,17 @@ import { assert_zod } from './middle.zod-validate.js';
  * @param {import("../types.public.js").App} app
  */
 export const db = app => app.db.resources.images;
-
+ 
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = async (app, item) => {
+async (item) => {
   assert_zod(imageTypeUpsertSchema, item);
 
   item.handle = to_handle(decodeURIComponent(item.name));
@@ -34,25 +38,24 @@ export const upsert = async (app, item) => {
   );
 
   await db(app).upsert(final, search);
+
   return final.id;
 }
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
 
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const remove = (app) => 
+/**
+ * 
  * @param {string} id
  */
-export const remove = async (app, id) => {
+async (id) => {
   // remove from storage
-  const img = await get(app, id);
+  const img = await regular_get(app, db(app))(id);
+
   if(!img) return;
 
   // remove from storage if it belongs
@@ -62,13 +65,6 @@ export const remove = async (app, id) => {
   // db remove image side-effect
   return app.db.resources.images.remove(img.id);
 }
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
 
 /**
  * url to name
@@ -90,4 +86,19 @@ export const image_url_to_handle = url => to_handle(image_url_to_name(url));
  */
 export const reportSearchAndUsageFromRegularDoc = async (app, data) => {
   await db(app).report_document_media(data)
+}
+
+
+/**
+ * 
+ * @param {import("../types.public.js").App} app
+ */  
+export const inter = app => {
+
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: remove(app),
+    list: regular_list(app, db(app)),
+  }
 }

--- a/packages/core/v-api/con.notifications.logic.js
+++ b/packages/core/v-api/con.notifications.logic.js
@@ -19,10 +19,14 @@ export const db = app => app.db.resources.notifications;
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const addBulk = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert[]} items
  * @return {Promise<import('../v-database/types.public.js').ID[]>}
  */
-export const addBulk = async (app, items) => {
+async (items) => {
   
   /** @type {(ItemTypeUpsert & import('../v-database/types.public.js').idable_concrete)[]} */
   const items_with_id = Array.isArray(items) ? items : [items] ;
@@ -40,27 +44,21 @@ export const addBulk = async (app, items) => {
   );
 
   await db(app).upsertBulk(items_with_id, search_terms);
+  
   return items_with_id.map(it => it.id);
 }
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, id, options) => regular_get(app, db(app))(id, options);
 
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
+ */  
+export const inter = app => {
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
+  return {
+    get: regular_get(app, db(app)),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+    addBulk: addBulk(app)
+  }
+}

--- a/packages/core/v-api/con.orders.logic.js
+++ b/packages/core/v-api/con.orders.logic.js
@@ -45,9 +45,13 @@ const create_search_index = (data) => {
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'order', orderDataUpsertSchema, 
   (final) => {
     return create_search_index(final);
@@ -58,22 +62,15 @@ export const upsert = (app, item) => regular_upsert(
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, id, options) => regular_get(app, db(app))(id, options);
+ */  
+export const inter = app => {
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+  }
+}
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
 

--- a/packages/core/v-api/con.posts.logic.js
+++ b/packages/core/v-api/con.posts.logic.js
@@ -16,9 +16,13 @@ export const db = app => app.db.resources.posts;
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'post', postTypeUpsertSchema, 
   (final) => {
     assert(
@@ -35,21 +39,15 @@ export const upsert = (app, item) => regular_upsert(
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
+ */  
+export const inter = app => {
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+  }
+}
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
+

--- a/packages/core/v-api/con.products.logic.js
+++ b/packages/core/v-api/con.products.logic.js
@@ -27,9 +27,13 @@ export const db = app => app.db.resources.products;
 /**
  * 
  * @param {App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'pr', productTypeUpsertSchema.or(variantTypeUpsertSchema), 
   (final) => {
 
@@ -52,60 +56,54 @@ export const upsert = (app, item) => regular_upsert(
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
  */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
-
+export const add_product_to_collection = (app) => 
 /**
  * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
  * @param {string} product handle or id
  * @param {string} collection handle or id
  */
-export const add_product_to_collection = (app, product, collection) => {
+(product, collection) => {
   return db(app).add_product_to_collection(product, collection);
 }
 
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const remove_product_from_collection = (app) => 
+/**
+ * 
  * @param {string} product handle or id
  * @param {string} collection handle or id
  */
-export const remove_product_from_collection = (app, product, collection) => {
+(product, collection) => {
   return db(app).remove_product_from_collection(product, collection);
 }
 
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const list_product_collections = (app) => 
+/**
+ * 
  * @param {string} handle_or_id handle or id
  */
-export const list_product_collections = (app, handle_or_id) => {
+(handle_or_id) => {
   return db(app).list_product_collections(handle_or_id);
 }
 
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const list_product_variants = (app) => 
+/**
+ * 
  * @param {string} product handle or id
  */
-export const list_product_variants = (app, product) => {
+(product) => {
   return db(app).list_product_variants(product);
 }
 
@@ -113,9 +111,13 @@ export const list_product_variants = (app, product) => {
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const list_related_products = (app) => 
+/**
+ * 
  * @param {string} product handle or id
  */
-export const list_related_products = (app, product) => {
+(product) => {
   return db(app).list_related_products(product);
 }
 
@@ -123,8 +125,33 @@ export const list_related_products = (app, product) => {
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const list_product_discounts = (app) => 
+/**
+ * 
  * @param {string} product handle or id
  */
-export const list_product_discounts = (app, product) => {
+(product) => {
   return db(app).list_product_discounts(product);
 }
+
+
+/**
+ * 
+ * @param {import("../types.public.js").App} app
+ */  
+export const inter = app => {
+
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+    list_product_collections: list_product_collections(app),
+    list_product_discounts: list_product_discounts(app),
+    list_product_variants: list_product_variants(app),
+    list_related_products: list_related_products(app),
+  }
+}
+
+

--- a/packages/core/v-api/con.shipping.logic.js
+++ b/packages/core/v-api/con.shipping.logic.js
@@ -15,9 +15,13 @@ export const db = app => app.db.resources.shipping;
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'ship', shippingMethodTypeUpsertSchema, 
   (final) => {
     return [];
@@ -28,21 +32,13 @@ export const upsert = (app, item) => regular_upsert(
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
+ */  
+export const inter = app => {
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+  }
+}

--- a/packages/core/v-api/con.statistics.logic.js
+++ b/packages/core/v-api/con.statistics.logic.js
@@ -43,16 +43,19 @@ const DAY = 86400000
 
 /**
  * 
- * Compute the `statistics` of `sales` / `orders` a period of time per day.
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const compute_statistics = app => 
+/**
+ * Compute the `statistics` of `sales` / `orders` a period of time per day.
+ * 
  * @param {string} [from_day] `ISO` / `UTC` / `timestamp` date
  * @param {string} [to_day] `ISO` / `UTC` / `timestamp` date
  * 
  * @returns {Promise<import('./types.api.js').OrdersStatisticsType>}
- * 
  */
-export const compute_statistics = async (app, from_day, to_day) => {
+async (from_day, to_day) => {
 
   const date_to_day = endOfDay(
     to_day ? new Date(to_day) : new Date()
@@ -242,13 +245,16 @@ const tables = [
  * Compute the count `statistics` of a table with `query`
  *  
  * @param {import("../types.public.js").App} app
+ */
+export const compute_count_of_query = app => 
+/**
+ * 
  * @param {keyof App["db"]["resources"]} [table] which `table` to get count of query
  * @param {import('./types.api.query.js').ApiQuery} [query] The `query` used for counting
  * 
  * @returns {Promise<number>}
- * 
  */
-export const compute_count_of_query = async (app, table, query) => {
+(table, query) => {
   assert(
     tables.includes(table),
     `Table ${table} is not allowed for counting !`
@@ -258,4 +264,17 @@ export const compute_count_of_query = async (app, table, query) => {
   const db = app.db?.resources?.[table];
 
   return db.count(query);
+}
+
+
+/**
+ * 
+ * @param {App} app 
+ */
+export const inter = app => {
+
+  return {
+    compute_count_of_query: compute_count_of_query(app),
+    compute_statistics: compute_statistics(app),
+  }
 }

--- a/packages/core/v-api/con.storefronts.logic.js
+++ b/packages/core/v-api/con.storefronts.logic.js
@@ -16,9 +16,13 @@ export const db = app => app.db.resources.storefronts;
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'sf', storefrontTypeUpsertSchema, 
   (final) => {
     assert(
@@ -31,66 +35,84 @@ export const upsert = (app, item) => regular_upsert(
   }
 )(item);
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options={ expand: ['*']}) => 
-      regular_get(app, db(app))(handle_or_id, options);
 
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} id
  */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
-
+export const list_storefront_products = (app) => 
 /**
  * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
  * @param {string} handle_or_id handle or id
  */
-export const list_storefront_products = (app, handle_or_id) => {
+(handle_or_id) => {
   return db(app).list_storefront_products(handle_or_id);
 }
 
 /**
  * @param {import("../types.public.js").App} app
+ */
+export const list_storefront_collections = (app) => 
+/**
+ * 
  * @param {string} handle_or_id handle or id
  */
-export const list_storefront_collections = (app, handle_or_id) => {
+(handle_or_id) => {
   return db(app).list_storefront_collections(handle_or_id);
 }
 
 /**
  * @param {import("../types.public.js").App} app
+ */
+export const list_storefront_discounts = (app) => 
+/**
+ * 
  * @param {string} handle_or_id handle or id
  */
-export const list_storefront_discounts = (app, handle_or_id) => {
+(handle_or_id) => {
   return db(app).list_storefront_discounts(handle_or_id);
 }
 
 /**
  * @param {import("../types.public.js").App} app
+ */
+export const list_storefront_shipping_methods = (app) => 
+/**
+ * 
  * @param {string} handle_or_id handle or id
  */
-export const list_storefront_shipping_methods = (app, handle_or_id) => {
+(handle_or_id) => {
   return db(app).list_storefront_shipping_methods(handle_or_id);
 }
 
 /**
  * @param {import("../types.public.js").App} app
+ */
+export const list_storefront_posts = (app) => 
+/**
+ * 
  * @param {string} handle_or_id handle or id
  */
-export const list_storefront_posts = (app, handle_or_id) => {
+(handle_or_id) => {
   return db(app).list_storefront_posts(handle_or_id);
+}
+
+
+/**
+ * 
+ * @param {import("../types.public.js").App} app
+ */  
+export const inter = app => {
+
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+    list_storefront_products: list_storefront_products(app),
+    list_storefront_collections: list_storefront_collections(app),
+    list_storefront_discounts: list_storefront_discounts(app),
+    list_storefront_posts: list_storefront_posts(app),
+    list_storefront_shipping_methods: list_storefront_shipping_methods(app),
+  }
 }

--- a/packages/core/v-api/con.tags.logic.js
+++ b/packages/core/v-api/con.tags.logic.js
@@ -16,9 +16,13 @@ export const db = app => app.db.resources.tags;
 /**
  * 
  * @param {import("../types.public.js").App} app
+ */
+export const upsert = (app) => 
+/**
+ * 
  * @param {ItemTypeUpsert} item
  */
-export const upsert = (app, item) => regular_upsert(
+(item) => regular_upsert(
   app, db(app), 'tag', tagTypeUpsertSchema, 
   (final) => {
     
@@ -36,21 +40,13 @@ export const upsert = (app, item) => regular_upsert(
 /**
  * 
  * @param {import("../types.public.js").App} app
- * @param {string} handle_or_id
- * @param {import('../v-database/types.public.js').RegularGetOptions} [options]
- */
-export const get = (app, handle_or_id, options) => regular_get(app, db(app))(handle_or_id, options);
+ */  
+export const inter = app => {
 
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {string} id
- */
-export const remove = (app, id) => regular_remove(app, db(app))(id);
-
-/**
- * 
- * @param {import("../types.public.js").App} app
- * @param {import('./types.api.query.js').ApiQuery} q
- */
-export const list = (app, q) => regular_list(app, db(app))(q);
+  return {
+    get: regular_get(app, db(app)),
+    upsert: upsert(app),
+    remove: regular_remove(app, db(app)),
+    list: regular_list(app, db(app)),
+  }
+}

--- a/packages/core/v-api/index.js
+++ b/packages/core/v-api/index.js
@@ -1,3 +1,4 @@
+// import { inter as discounts } from './con.discounts.logic.js';
 import { inter as discounts } from './con.discounts.logic.js';
 import { inter as collections } from './con.collections.logic.js';
 import { inter as customers } from './con.customers.logic.js';

--- a/packages/core/v-api/index.js
+++ b/packages/core/v-api/index.js
@@ -1,21 +1,48 @@
-export * as auth from './con.auth.logic.js';
-export * as checkout from './con.checkout.logic.js';
-export * as collections from './con.collections.logic.js';
-export * as customers from './con.customers.logic.js';
-export * as discounts from './con.discounts.logic.js';
-export * as images from './con.images.logic.js';
-export * as notifications from './con.notifications.logic.js';
-export * as orders from './con.orders.logic.js';
-export * as posts from './con.posts.logic.js';
-export * as pricing from './con.pricing.logic.js';
-export * as products from './con.products.logic.js';
-export * as shared from './con.shared.js';
-export * as shipping from './con.shipping.logic.js';
-export * as statistics from './con.statistics.logic.js';
-export * as storage from './con.storage.logic.js';
-export * as storefronts from './con.storefronts.logic.js';
-export * as tags from './con.tags.logic.js';
+import { inter as discounts } from './con.discounts.logic.js';
+import { inter as collections } from './con.collections.logic.js';
+import { inter as customers } from './con.customers.logic.js';
+import { inter as images } from './con.images.logic.js';
+import { inter as notifications } from './con.notifications.logic.js';
+import { inter as orders } from './con.orders.logic.js';
+import { inter as posts } from './con.posts.logic.js';
+import { inter as products } from './con.products.logic.js';
+import { inter as shipping } from './con.shipping.logic.js';
+import { inter as storefronts } from './con.storefronts.logic.js';
+import { inter as tags } from './con.tags.logic.js';
+import { inter as auth } from './con.auth.logic.js';
+import { inter as checkout } from './con.checkout.logic.js';
+import * as pricing from './con.pricing.logic.js';
+import { inter as statistics } from './con.statistics.logic.js';
 export * as func from './utils.func.js'
 export * as index from './utils.index.js'
 export * as query from './utils.query.js'
+import * as enums from './types.api.enums.js'
 export * as enums from './types.api.enums.js'
+import { App } from '../index.js';
+
+
+/**
+ * 
+ * @param {App} app 
+ */
+export const create_api = app => {
+  
+  return {
+    discounts: discounts(app),
+    collections: collections(app),
+    customers: customers(app),
+    images: images(app),
+    notifications: notifications(app),
+    orders: orders(app),
+    posts: posts(app),
+    products: products(app),
+    shipping: shipping(app),
+    storefronts: storefronts(app),
+    tags: tags(app),
+    auth: auth(app),
+    checkout: checkout(app),
+    statistics: statistics(app),
+    pricing,
+    enums
+  }
+}

--- a/packages/core/v-api/types.public.d.ts
+++ b/packages/core/v-api/types.public.d.ts
@@ -1,4 +1,3 @@
 export type * from './types.api.js'
 export type * from './types.api.query.js'
-// export * from './types.api.enums.js'
 export * from './public.js'

--- a/packages/core/v-api/utils.func.js
+++ b/packages/core/v-api/utils.func.js
@@ -1,5 +1,5 @@
 import { id } from '../v-crypto/object-id.js';
-
+ 
 export class StorecraftError extends Error {
   /**
    * 

--- a/packages/core/v-payments/con.payment-gateways.logic.js
+++ b/packages/core/v-payments/con.payment-gateways.logic.js
@@ -1,5 +1,4 @@
 import { assert } from '../v-api/utils.func.js'
-import { get } from '../v-api/con.orders.logic.js'
 import { App } from '../index.js';
 
 /** @param {any} o */
@@ -69,7 +68,7 @@ export const list_payment_gateways = (app) => {
  * 
  */
 export const payment_status_of_order = async (app, order_id) => {
-  const order = await get(app, order_id);
+  const order = await app.api.orders.get(order_id);
 
   assert(order, `Order ${order_id} not found`, 400);
 
@@ -104,7 +103,7 @@ export const invoke_payment_action_on_order = async (
   app, order_id, action_handle, extra_action_parameters
 ) => {
 
-  const order = await get(app, order_id);
+  const order = await app.api.orders.get(order_id);
 
   assert(order, `Order ${order_id} not found`, 400);
 

--- a/packages/core/v-ql/types.d.ts
+++ b/packages/core/v-ql/types.d.ts
@@ -15,3 +15,5 @@ export namespace VQL {
 
   export type AST = Node;
 }
+
+export * from './index.js'

--- a/packages/core/v-rest/con.auth.middle.js
+++ b/packages/core/v-rest/con.auth.middle.js
@@ -87,7 +87,7 @@ export const parse_basic_auth_or_apikey = (app) => {
       return;
     
     try {
-      const auth_user = await verify_api_key(app, { apikey });
+      const auth_user = await verify_api_key(app)({ apikey });
 
       if(auth_user) {
         req.user = {

--- a/packages/core/v-rest/con.auth.routes.js
+++ b/packages/core/v-rest/con.auth.routes.js
@@ -1,9 +1,4 @@
 import { Polka } from '../v-polka/index.js'
-import { 
-  create_api_key, get_auth_user, list_all_api_keys_info, 
-  list_auth_users, 
-  refresh, remove_auth_user, signin, signup 
-} from '../v-api/con.auth.logic.js'
 import { authorize_admin } from './con.auth.middle.js';
 import { parse_query } from '../v-api/utils.query.js';
 
@@ -22,11 +17,11 @@ export const create_routes = (app) => {
   /** @type {import('../types.public.js').ApiPolka} */
   const polka = new Polka();
 
-  // signup
+  // signup 
   polka.post(
     '/signup',
     async (req, res) => {
-      const result = await signup(app, req.parsedBody);
+      const result = await app.api.auth.signup(req.parsedBody);
       res.sendJson(result);
     }
   )
@@ -35,7 +30,7 @@ export const create_routes = (app) => {
   polka.post(
     '/signin',
     async (req, res) => {
-      const result = await signin(app, req.parsedBody);
+      const result = await app.api.auth.signin(req.parsedBody);
       res.sendJson(result);
     }
   )
@@ -44,7 +39,7 @@ export const create_routes = (app) => {
   polka.post(
     '/refresh',
     async (req, res) => {
-      const result = await refresh(app, req.parsedBody);
+      const result = await app.api.auth.refresh(req.parsedBody);
       res.sendJson(result);
     }
   )
@@ -55,7 +50,7 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
 
-      await remove_auth_user(app, req.params?.email);
+      await app.api.auth.remove_auth_user(req.params?.email);
 
       res.end();
     }
@@ -65,7 +60,7 @@ export const create_routes = (app) => {
     '/users/:email',
     middle_authorize_admin,
     async (req, res) => {
-      const item = await get_auth_user(app, req.params?.email);
+      const item = await app.api.auth.get_auth_user(req.params?.email);
 
       res.sendJson(item);
     }
@@ -78,7 +73,7 @@ export const create_routes = (app) => {
     async (req, res) => {
       let q = parse_query(req.query);
 
-      const items = await list_auth_users(app, q);
+      const items = await app.api.auth.list_auth_users(q);
 
       res.sendJson(items);
     }
@@ -89,7 +84,7 @@ export const create_routes = (app) => {
     '/apikeys',
     middle_authorize_admin,
     async (req, res) => {
-      const result = await create_api_key(app);
+      const result = await app.api.auth.create_api_key();
 
       res.sendJson(result);
     }
@@ -101,7 +96,7 @@ export const create_routes = (app) => {
     '/apikeys',
     middle_authorize_admin,
     async (req, res) => {
-      const result = await list_all_api_keys_info(app);
+      const result = await app.api.auth.list_all_api_keys_info();
 
       res.sendJson(result);
     }

--- a/packages/core/v-rest/con.checkout.routes.js
+++ b/packages/core/v-rest/con.checkout.routes.js
@@ -1,8 +1,6 @@
 import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { parse_auth_user, is_admin } from './con.auth.middle.js'
-import { complete_checkout, create_checkout, 
-  eval_pricing } from '../v-api/con.checkout.logic.js'
 
 /**
  * 
@@ -25,11 +23,15 @@ export const create_routes = (app) => {
     '/create',
     async (req, res) => {
       const gateway_handle = req.query?.get('gateway');
+
       assert(app.gateway(gateway_handle), `gateway ${gateway_handle} not found`, 400);
-      const r = await create_checkout(app, req.parsedBody, gateway_handle);
+
+      const r = await app.api.checkout.create_checkout(req.parsedBody, gateway_handle);
+
       if(!is_admin(req.user)) {
         delete r?.payment_gateway?.on_checkout_create;
       }
+
       res.sendJson(r);
     }
   );
@@ -39,10 +41,13 @@ export const create_routes = (app) => {
     '/:checkout_id/complete',
     async (req, res) => {
       const checkout_id = req?.params?.checkout_id;
-      const r = await complete_checkout(app, checkout_id);
+
+      const r = await app.api.checkout.complete_checkout(checkout_id);
+
       if(!is_admin(req.user)) {
         delete r?.payment_gateway?.on_checkout_create;
       }
+
       res.sendJson(r);
     }
   );
@@ -51,10 +56,12 @@ export const create_routes = (app) => {
   polka.post(
     '/pricing',
     async (req, res) => {
-      const r = await eval_pricing(app, req.parsedBody);
+      const r = await app.api.checkout.eval_pricing(req.parsedBody);
+
       if(!is_admin(req.user)) {
         delete r?.payment_gateway?.on_checkout_create;
       }
+
       res.sendJson(r);
     }
   );

--- a/packages/core/v-rest/con.collections.routes.js
+++ b/packages/core/v-rest/con.collections.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, list_collection_products, remove, upsert } from '../v-api/con.collections.logic.js'
 
 /**
  * 
@@ -20,12 +19,12 @@ export const create_routes = (app) => {
 
   const middle_authorize_admin = authorize_by_roles(app, ['admin'])
 
-  // save tag
+  // save tag 
   polka.post(
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.collections.upsert(req.parsedBody);
       res.sendJson(final);
     }
   )
@@ -35,8 +34,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.collections.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -47,7 +48,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.collections.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -57,7 +59,8 @@ export const create_routes = (app) => {
     '/',
     async (req, res) => {
       let q = parse_query(req.query);
-      const items = await list(app, q);
+      const items = await app.api.collections.list(q);
+
       res.sendJson(items);
     }
   );
@@ -67,8 +70,9 @@ export const create_routes = (app) => {
     '/:collection/products',
     async (req, res) => {
       const { collection } = req.params;
-      let q = parse_query(req.query);
-      const items = await list_collection_products(app, collection, q);
+      const q = parse_query(req.query);
+      const items = await app.api.collections.list_collection_products(collection, q);
+      
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.customers.routes.js
+++ b/packages/core/v-rest/con.customers.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { parse_auth_user, roles_guard } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, remove, upsert } from '../v-api/con.customers.logic.js'
 import { owner_or_admin_guard } from './con.customers.middle.js'
 
 /**
@@ -32,7 +31,7 @@ export const create_routes = (app) => {
     '/',
     owner_or_admin_guard,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.customers.upsert(req.parsedBody);
       res.sendJson(final);
     }
   )
@@ -43,8 +42,10 @@ export const create_routes = (app) => {
     owner_or_admin_guard,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.customers.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -55,7 +56,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.customers.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -65,8 +67,9 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.customers.list(q);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.discounts.routes.js
+++ b/packages/core/v-rest/con.discounts.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, list_discounts_products, remove, upsert } from '../v-api/con.discounts.logic.js'
 
 /**
  * @typedef {import('../v-api/types.api.js').DiscountType} ItemType
@@ -29,7 +28,8 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.discounts.upsert(req.parsedBody);
+
       res.sendJson(final);
     }
   )
@@ -39,8 +39,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.discounts.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -51,7 +53,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.discounts.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -60,8 +63,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.discounts.list(q);
+
       res.sendJson(items);
     }
   );
@@ -71,8 +75,9 @@ export const create_routes = (app) => {
     '/:discount/products',
     async (req, res) => {
       const { discount } = req?.params;
-      let q = parse_query(req.query);
-      const items = await list_discounts_products(app, discount, q);
+      const q = parse_query(req.query);
+      const items = await app.api.discounts.list_discounts_products(discount, q);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.images.routes.js
+++ b/packages/core/v-rest/con.images.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, remove, upsert } from '../v-api/con.images.logic.js'
 
 /**
  * @typedef {import('../v-api/types.api.js').ImageType} ItemType
@@ -29,7 +28,8 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.images.upsert(req.parsedBody);
+
       res.sendJson(final);
     }
   )
@@ -39,8 +39,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.images.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -51,7 +53,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.images.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -60,8 +63,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.images.list(q);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.notifications.routes.js
+++ b/packages/core/v-rest/con.notifications.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, remove, addBulk } from '../v-api/con.notifications.logic.js'
 
 /**
  * @typedef {import('../v-api/types.api.js').TagType} ItemType
@@ -29,7 +28,8 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await addBulk(app, req.parsedBody);
+      const final = await app.api.notifications.addBulk(req.parsedBody);
+
       res.sendJson(final);
     }
   )
@@ -39,8 +39,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.notifications.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -51,7 +53,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.notifications.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -60,8 +63,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.notifications.list(q);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.posts.routes.js
+++ b/packages/core/v-rest/con.posts.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, remove, upsert } from '../v-api/con.posts.logic.js'
 
 /**
  * @typedef {import('../v-api/types.api.js').TagType} ItemType
@@ -29,7 +28,8 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.posts.upsert(req.parsedBody);
+
       res.sendJson(final);
     }
   )
@@ -39,8 +39,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.posts.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -51,7 +53,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.posts.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -60,8 +63,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.posts.list(q);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.products.routes.js
+++ b/packages/core/v-rest/con.products.routes.js
@@ -2,11 +2,7 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_expand, parse_query } from '../v-api/utils.query.js'
-import { 
-  add_product_to_collection, get, list, 
-  list_product_collections, list_product_discounts, list_product_variants, 
-  list_related_products, remove, remove_product_from_collection, upsert 
-} from '../v-api/con.products.logic.js'
+
 
 /**
  * @typedef {import('../v-api/types.api.js').ProductType} ItemType
@@ -33,7 +29,8 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.products.upsert(req.parsedBody);
+
       res.sendJson(final);
     }
   )
@@ -47,8 +44,10 @@ export const create_routes = (app) => {
       const options = {
         expand: parse_expand(req.query)
       };
-      const item = await get(app, handle_or_id, options);
+      const item = await app.api.products.get(handle_or_id, options);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -59,7 +58,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.products.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -68,9 +68,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.products.list(q);
+
       res.sendJson(items);
     }
   );
@@ -81,7 +81,7 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const { product, collection } = req?.params;
-      await add_product_to_collection(app, product, collection);
+      await app.api.products.add_product_to_collection(product, collection);
       res.end();
     }
   );
@@ -92,7 +92,7 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const { product, collection } = req?.params;
-      await remove_product_from_collection(app, product, collection);
+      await app.api.products.remove_product_from_collection(product, collection);
       res.end();
     }
   );
@@ -101,7 +101,7 @@ export const create_routes = (app) => {
     '/:product/collections',
     async (req, res) => {
       const { product } = req?.params;
-      const items = await list_product_collections(app, product);
+      const items = await app.api.products.list_product_collections(product);
       res.sendJson(items);
     }
   );
@@ -110,7 +110,7 @@ export const create_routes = (app) => {
     '/:product/variants',
     async (req, res) => {
       const { product } = req?.params;
-      const items = await list_product_variants(app, product);
+      const items = await app.api.products.list_product_variants(product);
       res.sendJson(items);
     }
   );
@@ -119,7 +119,7 @@ export const create_routes = (app) => {
     '/:product/discounts',
     async (req, res) => {
       const { product } = req?.params;
-      const items = await list_product_discounts(app, product);
+      const items = await app.api.products.list_product_discounts(product);
       res.sendJson(items);
     }
   );
@@ -128,7 +128,7 @@ export const create_routes = (app) => {
     '/:product/related',
     async (req, res) => {
       const { product } = req?.params;
-      const items = await list_related_products(app, product);
+      const items = await app.api.products.list_related_products(product);
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.shipping.routes.js
+++ b/packages/core/v-rest/con.shipping.routes.js
@@ -2,7 +2,7 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, remove, upsert } from '../v-api/con.shipping.logic.js'
+
 
 /**
  * @typedef {import('../v-api/types.api.js').TagType} ItemType
@@ -29,7 +29,7 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.shipping.upsert(req.parsedBody);
       res.sendJson(final);
     }
   )
@@ -39,8 +39,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.shipping.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+
       res.sendJson(item);
     }
   );
@@ -51,7 +53,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.shipping.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -60,8 +63,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.shipping.list(q);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.statistics.routes.js
+++ b/packages/core/v-rest/con.statistics.routes.js
@@ -1,9 +1,7 @@
 import { Polka } from '../v-polka/index.js'
 import { authorize_by_roles } from './con.auth.middle.js'
-import { 
-  compute_count_of_query, compute_statistics 
-} from '../v-api/con.statistics.logic.js';
 import { parse_query } from '../v-api/utils.query.js';
+
 
 /**
  * 
@@ -30,8 +28,8 @@ export const create_routes = (app) => {
       const from_day = req?.query.get('fromDay');
       const to_day = req?.query.get('toDay');
 
-      const stats = await compute_statistics(
-        app, from_day, to_day
+      const stats = await app.api.statistics.compute_statistics(
+        from_day, to_day
       );
 
       res.sendJson(stats);
@@ -46,8 +44,8 @@ export const create_routes = (app) => {
       let q = parse_query(req.query);
       const table = req?.params?.table;
 
-      const count = await compute_count_of_query(
-        app, table, q
+      const count = await app.api.statistics.compute_count_of_query(
+        table, q
       );
 
       res.sendJson(count);

--- a/packages/core/v-rest/con.storefronts.routes.js
+++ b/packages/core/v-rest/con.storefronts.routes.js
@@ -2,10 +2,7 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, list_storefront_collections, 
-  list_storefront_discounts, list_storefront_posts, 
-  list_storefront_products, list_storefront_shipping_methods, 
-  remove, upsert } from '../v-api/con.storefronts.logic.js'
+
 
 /**
  * @typedef {import('../v-api/types.api.js').TagType} ItemType
@@ -32,7 +29,7 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.storefronts.upsert(req.parsedBody);
       res.sendJson(final);
     }
   )
@@ -42,8 +39,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.storefronts.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+      
       res.sendJson(item);
     }
   );
@@ -54,7 +53,8 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.storefronts.remove(handle_or_id);
+
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -63,8 +63,9 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      let q = parse_query(req.query);
-      const items = await list(app, q);
+      const q = parse_query(req.query);
+      const items = await app.api.storefronts.list(q);
+
       res.sendJson(items);
     }
   );
@@ -74,7 +75,8 @@ export const create_routes = (app) => {
     '/:handle/products',
     async (req, res) => {
       const { handle } = req.params;
-      const items = await list_storefront_products(app, handle);
+      const items = await app.api.storefronts.list_storefront_products(handle);
+
       res.sendJson(items);
     }
   );
@@ -83,7 +85,8 @@ export const create_routes = (app) => {
     '/:handle/collections',
     async (req, res) => {
       const { handle } = req.params;
-      const items = await list_storefront_collections(app, handle);
+      const items = await app.api.storefronts.list_storefront_collections(handle);
+
       res.sendJson(items);
     }
   );
@@ -92,7 +95,8 @@ export const create_routes = (app) => {
     '/:handle/discounts',
     async (req, res) => {
       const { handle } = req.params;
-      const items = await list_storefront_discounts(app, handle);
+      const items = await app.api.storefronts.list_storefront_discounts(handle);
+
       res.sendJson(items);
     }
   );
@@ -101,7 +105,8 @@ export const create_routes = (app) => {
     '/:handle/shipping_methods',
     async (req, res) => {
       const { handle } = req.params;
-      const items = await list_storefront_shipping_methods(app, handle);
+      const items = await app.api.storefronts.list_storefront_shipping_methods(handle);
+      
       res.sendJson(items);
     }
   );
@@ -110,7 +115,8 @@ export const create_routes = (app) => {
     '/:handle/posts',
     async (req, res) => {
       const { handle } = req.params;
-      const items = await list_storefront_posts(app, handle);
+      const items = await app.api.storefronts.list_storefront_posts(handle);
+
       res.sendJson(items);
     }
   );

--- a/packages/core/v-rest/con.tags.routes.js
+++ b/packages/core/v-rest/con.tags.routes.js
@@ -2,7 +2,6 @@ import { Polka } from '../v-polka/index.js'
 import { assert } from '../v-api/utils.func.js'
 import { authorize_by_roles } from './con.auth.middle.js'
 import { parse_query } from '../v-api/utils.query.js'
-import { get, list, remove, upsert } from '../v-api/con.tags.logic.js'
 
 /**
  * @typedef {import('../v-api/types.api.js').TagType} ItemType
@@ -29,7 +28,7 @@ export const create_routes = (app) => {
     '/',
     middle_authorize_admin,
     async (req, res) => {
-      const final = await upsert(app, req.parsedBody);
+      const final = await app.api.tags.upsert(req.parsedBody);
       res.sendJson(final);
     }
   )
@@ -39,8 +38,10 @@ export const create_routes = (app) => {
     '/:handle',
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const item = await get(app, handle_or_id);
+      const item = await app.api.tags.get(handle_or_id);
+
       assert(item, 'not-found', 404);
+      
       res.sendJson(item);
     }
   );
@@ -51,7 +52,7 @@ export const create_routes = (app) => {
     middle_authorize_admin,
     async (req, res) => {
       const handle_or_id = req?.params?.handle;
-      const removed = handle_or_id && await remove(app, handle_or_id);
+      const removed = handle_or_id && await app.api.tags.remove(handle_or_id);
       res.setStatus(removed ? 200 : 404).end();
     }
   );
@@ -61,7 +62,7 @@ export const create_routes = (app) => {
     '/',
     async (req, res) => {
       let q = parse_query(req.query);
-      const items = await list(app, q);
+      const items = await app.api.tags.list(q);
       res.sendJson(items);
     }
   );

--- a/packages/dashboard/src/admin/comps/common-button.jsx
+++ b/packages/dashboard/src/admin/comps/common-button.jsx
@@ -175,7 +175,7 @@ export const PromisableLoadingButton = (
  */
 export const PromisableLoadingBlingButton = (
   {
-    onClick, show=true, className, loading: $loading, 
+    onClick, show=true, className='h-6', loading: $loading, 
     stroke='p-px', rounded='rounded-full', 
     from='from-pink-300 dark:from-pink-500',
     to='to-kf-300 dark:to-kf-500',

--- a/packages/database-mongodb-node/driver.js
+++ b/packages/database-mongodb-node/driver.js
@@ -87,12 +87,10 @@ export class MongoDB {
       db_name: c?.db_name ?? app.platform.env.MONGODB_NAME ?? 'main'
     }
 
-    const now = Date.now();
     this.#_mongo_client = await connect(
       this.config.url,
       this.config.options
     );
-    console.log('mongo connect: ' + (Date.now()-now));
    
     this.#_app = app;
 

--- a/packages/database-mongodb-node/driver.js
+++ b/packages/database-mongodb-node/driver.js
@@ -87,11 +87,13 @@ export class MongoDB {
       db_name: c?.db_name ?? app.platform.env.MONGODB_NAME ?? 'main'
     }
 
+    const now = Date.now();
     this.#_mongo_client = await connect(
       this.config.url,
       this.config.options
     );
-
+    console.log('mongo connect: ' + (Date.now()-now));
+   
     this.#_app = app;
 
     this.resources = {

--- a/packages/database-mongodb-node/src/con.auth_users.js
+++ b/packages/database-mongodb-node/src/con.auth_users.js
@@ -1,6 +1,6 @@
 import { MongoDB } from '../driver.js'
 import { Collection } from 'mongodb'
-import { sanitize_one, to_objid } from './utils.funcs.js'
+import { sanitize_one, to_objid, to_objid_safe } from './utils.funcs.js'
 import { 
   count_regular, get_regular, list_regular, upsert_regular 
 } from './con.shared.js'
@@ -61,7 +61,7 @@ const remove = (driver) => {
     const res = await col(driver).deleteOne(
       { 
         '$or': [
-          { _id: to_objid(id) },
+          { _id: to_objid_safe(id) },
           { email: String(id) }
         ]
       }

--- a/packages/database-mongodb-node/src/con.images.js
+++ b/packages/database-mongodb-node/src/con.images.js
@@ -3,8 +3,11 @@ import { MongoDB } from '../driver.js'
 import { count_regular, get_regular, list_regular, 
   upsert_regular } from './con.shared.js'
 import { handle_or_id, to_objid } from './utils.funcs.js';
-import { images, func } from '@storecraft/core/v-api';
+import { func } from '@storecraft/core/v-api';
 import { ID } from '@storecraft/core/v-api/utils.func.js';
+import { 
+  image_url_to_handle, image_url_to_name 
+} from '@storecraft/core/v-api/con.images.logic.js';
 
 /**
  * @typedef {import('@storecraft/core/v-database').db_images} db_col
@@ -110,11 +113,11 @@ export const report_document_media = (driver) => {
       const id_on_insert = ID('img');
       return {
         updateOne: {
-          filter: { handle: images.image_url_to_handle(url) },
+          filter: { handle: image_url_to_handle(url) },
           update: { 
             $addToSet : { '_relations.search': { $each: add_to_search_index} },
             $set: { 
-              name: images.image_url_to_name(url),
+              name: image_url_to_name(url),
               url: url,
               updated_at: dates.updated_at
             },

--- a/packages/database-mongodb-node/src/con.products.js
+++ b/packages/database-mongodb-node/src/con.products.js
@@ -18,9 +18,11 @@ import {
   update_specific_connection_of_relation_with_filter
 } from './utils.relations.js'
 import { enums } from '@storecraft/core/v-api'
-import { pricing } from '@storecraft/core/v-api'
 import { report_document_media } from './con.images.js'
 import { union } from '@storecraft/core/v-api/utils.func.js'
+import { 
+  test_product_filters_against_product 
+} from '@storecraft/core/v-api/con.pricing.logic.js'
 
 /**
  * @typedef {import('@storecraft/core/v-database').db_products} db_col
@@ -81,7 +83,7 @@ const upsert = (driver) => {
           ).toArray();
           // now test locally
           const eligible_discounts = discounts.filter(
-            d => pricing.test_product_filters_against_product(
+            d => test_product_filters_against_product(
               d.info.filters, replacement
             )
           );
@@ -172,7 +174,7 @@ const upsert = (driver) => {
     return true;
   }
 }
-
+ 
 /**
  * @param {MongoDB} driver 
  */

--- a/packages/database-mongodb-node/src/utils.funcs.js
+++ b/packages/database-mongodb-node/src/utils.funcs.js
@@ -101,6 +101,20 @@ export const to_objid = id => new ObjectId(id.split('_').at(-1))
 
 /**
  * 
+ * @param {string} id 
+ * 
+ */
+export const to_objid_safe = id => {
+  try {
+    return  new ObjectId(id.split('_').at(-1))
+  } catch(e) {
+  }
+
+  return undefined;
+}
+
+/**
+ * 
  * @param {string} handle_or_id 
  * 
  * 

--- a/packages/database-mongodb-node/src/utils.query.js
+++ b/packages/database-mongodb-node/src/utils.query.js
@@ -1,4 +1,3 @@
-import { parse_query } from "@storecraft/core/v-api/utils.query.js";
 import { to_objid } from "./utils.funcs.js";
 import { parse } from "@storecraft/core/v-ql";
 

--- a/packages/database-mongodb-node/src/utils.relations.js
+++ b/packages/database-mongodb-node/src/utils.relations.js
@@ -31,8 +31,10 @@ import { MongoDB } from '../driver.js';
  * 
  * @param {MongoDB} driver our driver
  * @param {T} data data to create the connection from
- * @param {string} fieldName the field name, that represents a relation, a field with { id } property
- * @param {string} belongsToCollection which collection does the field relate to
+ * @param {string} fieldName the field name, that represents 
+ * a relation, a field with { id } property
+ * @param {string} belongsToCollection which collection 
+ * does the field relate to
  * @param {boolean} [reload=false] re-retrive documents ?
  * 
  * 
@@ -93,7 +95,7 @@ export const create_explicit_relation = async (
  * 
  * @template {Object.<string, any>} T
  * 
- * @param {T} data 
+ * @param {WithRelations<T>} data 
  * @param {string[]} terms 
  * 
  */

--- a/packages/database-mongodb-node/tests/runner.test.js
+++ b/packages/database-mongodb-node/tests/runner.test.js
@@ -8,7 +8,7 @@ export const create_app = async () => {
     new NodePlatform(),
     new MongoDB({ db_name: 'test'}),
     null, null, null, null, {
-      admins_emails: ['admin@sc.com'],
+      auth_admins_emails: ['admin@sc.com'],
       auth_password_hash_rounds: 100,
       auth_secret_access_token: 'auth_secret_access_token',
       auth_secret_refresh_token: 'auth_secret_refresh_token'

--- a/packages/database-sql-base/src/con.images.js
+++ b/packages/database-sql-base/src/con.images.js
@@ -1,4 +1,4 @@
-import { func, images } from '@storecraft/core/v-api'
+import { func } from '@storecraft/core/v-api'
 import { SQL } from '../driver.js'
 import { count_regular, delete_me, delete_search_of, 
   insert_entity_array_values_of, 
@@ -9,6 +9,7 @@ import { query_to_eb, query_to_sort } from './utils.query.js'
 // import { ID } from '@storecraft/core/v-api/utils.func.js'
 import { Transaction } from 'kysely'
 import { ID } from '@storecraft/core/v-api/utils.func.js'
+import { image_url_to_handle, image_url_to_name } from '@storecraft/core/v-api/con.images.logic.js'
 
 /**
  * @typedef {import('@storecraft/core/v-database').db_images} db_col
@@ -122,9 +123,9 @@ export const report_document_media = (driver) => {
       const ms = item.media.map(
         m => (
           {
-            handle: images.image_url_to_handle(m),
+            handle: image_url_to_handle(m),
             url: m,
-            name: images.image_url_to_name(m),
+            name: image_url_to_name(m),
             id: ID('img'),
             created_at: dates.created_at,
             updated_at: dates.updated_at,

--- a/packages/database-sql-base/src/con.products.js
+++ b/packages/database-sql-base/src/con.products.js
@@ -13,7 +13,6 @@ import { delete_entity_values_of_by_entity_id_or_handle, delete_me, delete_media
   products_with_related_products} from './con.shared.js'
 import { sanitize_array, sanitize } from './utils.funcs.js'
 import { query_to_eb, query_to_sort } from './utils.query.js'
-import { pricing } from '@storecraft/core/v-api'
 import { Transaction } from 'kysely'
 import { report_document_media } from './con.images.js'
 
@@ -42,6 +41,7 @@ const is_variant = item => {
 const upsert = (driver) => {
   return async (item, search_terms) => {
     const c = driver.client;
+    
     try {
       // The product has changed, it's discounts eligibility may have changed.
       // get all automatic + active discounts
@@ -55,7 +55,7 @@ const upsert = (driver) => {
         ])
       ).execute();
       const eligible_discounts = discounts.filter(
-        d => pricing.test_product_filters_against_product(d.info.filters, item)
+        d => driver.app.api.pricing.test_product_filters_against_product(d.info.filters, item)
       );      
 
       const t = await driver.client.transaction().execute(

--- a/packages/database-sql-base/tests/runner.mssql-local.test.js
+++ b/packages/database-sql-base/tests/runner.mssql-local.test.js
@@ -41,7 +41,7 @@ export const create_app = async () => {
       dialect_type: 'MSSQL'
     }),
     null, null, null, null, {
-      admins_emails: ['admin@sc.com'],
+      auth_admins_emails: ['admin@sc.com'],
       auth_password_hash_rounds: 100,
       auth_secret_access_token: 'auth_secret_access_token',
       auth_secret_refresh_token: 'auth_secret_refresh_token'

--- a/packages/database-sql-base/tests/runner.mysql-local.test.js
+++ b/packages/database-sql-base/tests/runner.mysql-local.test.js
@@ -23,7 +23,7 @@ export const create_app = async () => {
       dialect_type: 'MYSQL'
     }),
     null, null, null, null, {
-      admins_emails: ['admin@sc.com'],
+      auth_admins_emails: ['admin@sc.com'],
       auth_password_hash_rounds: 100,
       auth_secret_access_token: 'auth_secret_access_token',
       auth_secret_refresh_token: 'auth_secret_refresh_token'

--- a/packages/database-sql-base/tests/runner.postgres-local.test.js
+++ b/packages/database-sql-base/tests/runner.postgres-local.test.js
@@ -22,7 +22,7 @@ export const create_app = async () => {
       dialect_type: 'POSTGRES'
     }),
     null, null, null, null, {
-      admins_emails: ['admin@sc.com'],
+      auth_admins_emails: ['admin@sc.com'],
       auth_password_hash_rounds: 100,
       auth_secret_access_token: 'auth_secret_access_token',
       auth_secret_refresh_token: 'auth_secret_refresh_token'

--- a/packages/database-sql-base/tests/runner.sqlite-local.test.js
+++ b/packages/database-sql-base/tests/runner.sqlite-local.test.js
@@ -19,7 +19,7 @@ export const create_app = async () => {
       dialect_type: 'SQLITE'
     }),
     null, null, null, null, {
-      admins_emails: ['admin@sc.com'],
+      auth_admins_emails: ['admin@sc.com'],
       auth_password_hash_rounds: 100,
       auth_secret_access_token: 'auth_secret_access_token',
       auth_secret_refresh_token: 'auth_secret_refresh_token'

--- a/packages/playground/index.js
+++ b/packages/playground/index.js
@@ -11,7 +11,6 @@ import { GoogleStorage } from '@storecraft/storage-google'
 import { PaypalStandard } from '@storecraft/payments-paypal-standard'
 import { App } from '@storecraft/core';
  
-const now = Date.now();
 let app = new App(
   new NodePlatform(),
   new MongoDB({ db_name: 'test' }),
@@ -26,11 +25,6 @@ let app = new App(
 
 await app.init();
  
-const now2 = Date.now();
-const delta = ((now2 - now));
-console.log('init in ' + delta + ' ms')
-
-
 const server = http.createServer(app.handler).listen(
   8000,
   () => {

--- a/packages/playground/index.js
+++ b/packages/playground/index.js
@@ -11,6 +11,7 @@ import { GoogleStorage } from '@storecraft/storage-google'
 import { PaypalStandard } from '@storecraft/payments-paypal-standard'
 import { App } from '@storecraft/core';
  
+const now = Date.now();
 let app = new App(
   new NodePlatform(),
   new MongoDB({ db_name: 'test' }),
@@ -25,6 +26,11 @@ let app = new App(
 
 await app.init();
  
+const now2 = Date.now();
+const delta = ((now2 - now));
+console.log('init in ' + delta + ' ms')
+
+
 const server = http.createServer(app.handler).listen(
   8000,
   () => {

--- a/packages/test-runner/api_auth_test.js
+++ b/packages/test-runner/api_auth_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { auth } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { file_name } from './api.utils.crud.js';
@@ -22,8 +21,8 @@ export const create = app => {
   s.before(async () => { assert.ok(app.ready) });
   
   s('remove and signup admin', async () => {
-    await auth.removeByEmail(app, admin_email);
-    const r = await auth.signup(app, {
+    await app.api.auth.removeByEmail(admin_email);
+    const r = await app.api.auth.signup({
       email: admin_email,
       password: admin_password
     });
@@ -34,7 +33,7 @@ export const create = app => {
   });
   
   s('signin admin', async () => {
-    const r = await auth.signin(app, {
+    const r = await app.api.signin(app, {
       email: admin_email,
       password: admin_password
     });
@@ -46,11 +45,11 @@ export const create = app => {
   
   s('refresh admin', async () => {
   
-    const u = await auth.signin(app, {
+    const u = await app.api.auth.signin({
       email: admin_email,
       password: admin_password
     });
-    const r = await auth.refresh(app, {
+    const r = await app.api.auth.refresh({
       refresh_token: u.refresh_token.token
     });
   
@@ -61,8 +60,8 @@ export const create = app => {
 
   s('apikey create, validate, list and remove', async () => {
   
-    const apikey_created = await auth.create_api_key(app);
-    const isvalid = await auth.verify_api_key(app, {
+    const apikey_created = await app.api.auth.create_api_key();
+    const isvalid = await app.api.auth.verify_api_key({
       apikey: apikey_created.apikey
     });
     const apikey_created_decoded_email = atob(apikey_created.apikey).split(':').at(0);
@@ -71,7 +70,7 @@ export const create = app => {
 
     // now list only api keys
     {
-      const apikeys = await auth.list_all_api_keys_info(app);
+      const apikeys = await app.api.auth.list_all_api_keys_info();
       let is_apikey_created_present = false;
 
       assert.ok(apikeys?.length, 'no api keys were found');
@@ -92,9 +91,9 @@ export const create = app => {
 
     {
       // now remove
-      await auth.remove_auth_user(app, apikey_created_decoded_email);
+      await app.api.auth.remove_auth_user(apikey_created_decoded_email);
 
-      const apikeys = await auth.list_all_api_keys_info(app);
+      const apikeys = await app.api.auth.list_all_api_keys_info();
 
       assert.ok(
         apikeys.every(ak => ak.email!==apikey_created_decoded_email), 

--- a/packages/test-runner/api_auth_test.js
+++ b/packages/test-runner/api_auth_test.js
@@ -33,7 +33,7 @@ export const create = app => {
   });
   
   s('signin admin', async () => {
-    const r = await app.api.signin(app, {
+    const r = await app.api.auth.signin({
       email: admin_email,
       password: admin_password
     });

--- a/packages/test-runner/api_collections_crud_test.js
+++ b/packages/test-runner/api_collections_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { collections } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { add_sanity_crud_to_test_suite, 
@@ -40,7 +39,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: collections }
+    { items: items_upsert, app, ops: app.api.collections }
   );
 
   s.before(
@@ -48,7 +47,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await collections.remove(app, p.handle);
+          await app.api.collections.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;

--- a/packages/test-runner/api_collections_list_test.js
+++ b/packages/test-runner/api_collections_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { collections } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -47,7 +46,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: collections,
+      items: items, app, ops: app.api.collections,
       resource: 'collections'
     }
   );
@@ -57,7 +56,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await collections.remove(app, p.handle);
+          await app.api.collections.remove(p.handle);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.collections.upsert(p);

--- a/packages/test-runner/api_collections_products_test.js
+++ b/packages/test-runner/api_collections_products_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { collections, products } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, promises_sequence } from './api.utils.crud.js';
@@ -64,9 +63,9 @@ export const create = app => {
       assert.ok(app.ready);
 
       for(const p of pr_upsert)
-        await products.remove(app, p.handle);
+        await app.api.products.remove(p.handle);
       for(const p of col_upsert)
-        await collections.remove(app, p.handle);
+        await app.api.collections.remove(p.handle);
     }
   );
 
@@ -78,8 +77,8 @@ export const create = app => {
     const cols = await promises_sequence(
       col_upsert.map(
         c => async () => {
-          await collections.upsert(app, c);
-          return collections.get(app, c.handle);
+          await app.api.collections.upsert(c);
+          return app.api.collections.get(c.handle);
         }
       )
     );
@@ -88,8 +87,8 @@ export const create = app => {
     const prs = await promises_sequence(
       pr_upsert.map(
         c => async () => {
-          await products.upsert(app, c);
-          return products.get(app, c.handle);
+          await app.api.products.upsert(c);
+          return app.api.products.get(c.handle);
         }
       )
     );
@@ -97,7 +96,7 @@ export const create = app => {
     // console.log('prs', prs)
     // upsert products with collections relation
     for (const pr of prs) {
-      await products.upsert(app, {
+      await app.api.products.upsert({
         ...pr, 
         collections: cols
       });
@@ -105,8 +104,8 @@ export const create = app => {
 
     // console.log('prs', prs)
     // now query list of products of collection
-    const products_queried = await collections.list_collection_products(
-      app, col_upsert[0].handle,
+    const products_queried = await app.api.collections.list_collection_products(
+      col_upsert[0].handle,
       {
         startAt: [['id', prs[0].id]], 
         sortBy: ['id'],

--- a/packages/test-runner/api_customers_crud_test.js
+++ b/packages/test-runner/api_customers_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { customers } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { file_name, add_sanity_crud_to_test_suite, 
@@ -28,7 +27,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: customers }
+    { items: items_upsert, app, ops: app.api.customers }
   );
 
   s.before(
@@ -36,9 +35,9 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert) {
-          const get = await customers.getByEmail(app, p.email);
+          const get = await app.api.customers.getByEmail(p.email);
           if(get)
-            await customers.remove(app, get.id);
+            await app.api.customers.remove(get.id);
         }
       } catch(e) {
         console.log(e)

--- a/packages/test-runner/api_customers_list_test.js
+++ b/packages/test-runner/api_customers_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { customers } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -45,7 +44,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: customers,
+      items: items, app, ops: app.api.customers,
       resource: 'customers' 
     }
   );
@@ -55,7 +54,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          const success = await customers.remove(app, p.email);
+          const success = await app.api.customers.remove(p.email);
 
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps

--- a/packages/test-runner/api_discounts_crud_test.js
+++ b/packages/test-runner/api_discounts_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { discounts } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { enums } from '@storecraft/core/v-api';
@@ -57,7 +56,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: discounts }
+    { items: items_upsert, app, ops: app.api.discounts }
   );
 
   s.before(
@@ -65,7 +64,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert) {
-          const get = await discounts.remove(app, p.handle);
+          const get = await app.api.discounts.remove(p.handle);
         }
       } catch(e) {
         console.log(e)

--- a/packages/test-runner/api_discounts_list_test.js
+++ b/packages/test-runner/api_discounts_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { discounts } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { file_name, 
@@ -68,7 +67,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: discounts,
+      items: items, app, ops: app.api.discounts,
       resource: 'discounts'
     }
   );
@@ -78,7 +77,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await discounts.remove(app, p.handle);
+          await app.api.discounts.remove(p.handle);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.discounts.upsert(p);

--- a/packages/test-runner/api_discounts_products_test.js
+++ b/packages/test-runner/api_discounts_products_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { discounts, products } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { enums } from '@storecraft/core/v-api';
@@ -99,9 +98,9 @@ export const create = app => {
       assert.ok(app.ready);
 
       for(const p of pr_upsert)
-        await products.remove(app, p.handle);
+        await app.api.products.remove(p.handle);
       for(const p of discounts_upsert)
-        await discounts.remove(app, p.handle);
+        await app.api.discounts.remove(p.handle);
     }
   );
 
@@ -110,8 +109,8 @@ export const create = app => {
     const prs = await promises_sequence(
       pr_upsert.map(
         c => async () => {
-          await products.upsert(app, c);
-          return products.get(app, c.handle);
+          await app.api.products.upsert(c);
+          return app.api.products.get(c.handle);
         }
       )
     );
@@ -120,8 +119,8 @@ export const create = app => {
     const dis = await promises_sequence(
       discounts_upsert.map(
         c => async () => {
-          await discounts.upsert(app, c);
-          return discounts.get(app, c.handle);
+          await app.api.discounts.upsert(c);
+          return app.api.discounts.get(c.handle);
         }
       )
     );
@@ -130,8 +129,8 @@ export const create = app => {
 
     // now assert, each product and discount applied
     for(let ix = 0; ix < discounts_upsert.length; ix++) {
-      const products_queried = await discounts.list_discounts_products(
-        app, discounts_upsert[ix].handle,
+      const products_queried = await app.api.discounts.list_discounts_products(
+        discounts_upsert[ix].handle,
         {
           startAt: [['id', prs[ix].id]],
           sortBy: ['id'],

--- a/packages/test-runner/api_images_crud_test.js
+++ b/packages/test-runner/api_images_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { images } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { add_sanity_crud_to_test_suite, file_name } from './api.utils.crud.js';
@@ -27,7 +26,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: images }
+    { items: items_upsert, app, ops: app.api.images }
   );
 
   s.before(
@@ -35,7 +34,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await images.remove(app, p.handle);
+          await app.api.images.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;

--- a/packages/test-runner/api_images_list_test.js
+++ b/packages/test-runner/api_images_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { images } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { file_name, 
@@ -47,7 +46,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: images,
+      items: items, app, ops: app.api.images,
       resource: 'images'
     }
   );
@@ -57,7 +56,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await images.remove(app, p.handle);
+          await app.api.images.remove(p.handle);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.images.upsert(p);

--- a/packages/test-runner/api_notifications_crud_test.js
+++ b/packages/test-runner/api_notifications_crud_test.js
@@ -1,4 +1,3 @@
-import { notifications } from '@storecraft/core/v-api';
 import 'dotenv/config';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
@@ -37,12 +36,12 @@ export const create = app => {
   );
   
   s.before(async () => { assert.ok(app.ready) });
-  const ops = notifications;
+  const ops = app.api.notifications;
 
   s('add', async () => {
     const one = items_upsert[0];
     const ids = await ops.addBulk(
-      app, items_upsert
+      items_upsert
     );
 
     assert.ok(ids?.length)

--- a/packages/test-runner/api_notifications_list_test.js
+++ b/packages/test-runner/api_notifications_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { notifications } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { file_name, 
@@ -53,7 +52,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: notifications,
+      items: items, app, ops: app.api.notifications,
       resource: 'notifications'
     }
   );
@@ -63,7 +62,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await notifications.remove(app, p.id);
+          await app.api.notifications.remove(p.id);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.notifications.upsert(p);

--- a/packages/test-runner/api_orders_crud_test.js
+++ b/packages/test-runner/api_orders_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { orders } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { enums } from '@storecraft/core/v-api';
@@ -59,7 +58,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: orders }
+    { items: items_upsert, app, ops: app.api.orders }
   );
 
   s.before(

--- a/packages/test-runner/api_orders_list_test.js
+++ b/packages/test-runner/api_orders_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { orders } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { file_name, iso, add_list_integrity_tests,
@@ -58,7 +57,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: orders,
+      items: items, app, ops: app.api.orders,
       resource: 'orders'
     }
   );
@@ -68,7 +67,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await orders.remove(app, p.id);
+          await app.api.orders.remove(p.id);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
             await app.db.resources.orders.upsert(p);

--- a/packages/test-runner/api_posts_crud_test.js
+++ b/packages/test-runner/api_posts_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { posts } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { add_sanity_crud_to_test_suite, 
@@ -31,7 +30,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: posts }
+    { items: items_upsert, app, ops: app.api.posts }
   );
 
   s.before(
@@ -39,7 +38,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await posts.remove(app, p.handle);
+          await app.api.posts.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;

--- a/packages/test-runner/api_posts_list_test.js
+++ b/packages/test-runner/api_posts_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { posts } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -45,7 +44,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: posts,
+      items: items, app, ops: app.api.posts,
       resource: 'posts'
     }
   );
@@ -55,7 +54,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await posts.remove(app, p.handle);
+          await app.api.posts.remove(p.handle);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.posts.upsert(p);

--- a/packages/test-runner/api_products_crud_test.js
+++ b/packages/test-runner/api_products_crud_test.js
@@ -1,8 +1,9 @@
 import 'dotenv/config';
-import { products } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
-import { add_sanity_crud_to_test_suite, create_handle, file_name } from './api.utils.crud.js';
+import { 
+  add_sanity_crud_to_test_suite, create_handle, file_name 
+} from './api.utils.crud.js';
 import { App } from '@storecraft/core';
 import esMain from './utils.esmain.js';
 
@@ -41,7 +42,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: products }
+    { items: items_upsert, app, ops: app.api.products }
   );
   
   s.before(
@@ -49,7 +50,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await products.remove(app, p.handle);
+          await app.api.products.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;

--- a/packages/test-runner/api_products_list_test.js
+++ b/packages/test-runner/api_products_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { products, collections } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -66,7 +65,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: products,
+      items: items, app, ops: app.api.products,
       resource: 'products'
     }
   );
@@ -76,12 +75,12 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of collections_upsert) {
-          await collections.remove(app, p.handle);
+          await app.api.collections.remove(p.handle);
           await app.db.resources.collections.upsert(p);
         }
 
         for(const p of items) {
-          await products.remove(app, p.handle);
+          await app.api.products.remove(p.handle);
           // add collections
           p.collections = collections_upsert;
           // we bypass the api and upsert straight

--- a/packages/test-runner/api_products_related_products_test.js
+++ b/packages/test-runner/api_products_related_products_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { products } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { App } from '@storecraft/core';
@@ -58,9 +57,9 @@ export const create = app => {
     async () => { 
       assert.ok(app.ready);
       try {
-        await products.remove(app, pr_upsert.handle);
+        await app.api.products.remove(pr_upsert.handle);
         for(const p of related_product_upsert)
-          await products.remove(app, p.handle);
+          await app.api.products.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;
@@ -76,7 +75,7 @@ export const create = app => {
 
     // upsert all variants
     const ids = await promises_sequence(
-      related_product_upsert.map(v => () => products.upsert(app, v))
+      related_product_upsert.map(v => () => app.api.products.upsert(v))
     )
 
     // console.log('ids', ids)
@@ -91,15 +90,17 @@ export const create = app => {
 
 
     // now query the product's discounts to see if discount was applied to 1st product
-    const related_products = await products.list_related_products(
-      app, pr_upsert.handle
+    const related_products = await app.api.products.list_related_products(
+      pr_upsert.handle
     );
 
     // console.log('related_products', related_products)
 
     assert.ok(related_products.length>=related_product_upsert.length, 'got less')
     assert.ok(
-      related_product_upsert.every((v) => related_products.find(x => x.handle===v.handle)), 
+      related_product_upsert.every(
+        (v) => related_products.find(x => x.handle===v.handle)
+      ), 
       'got less'
     );
   });
@@ -108,13 +109,13 @@ export const create = app => {
     // upsert 1st product straight to the db because we have ID
     const remove_handle = related_product_upsert[0].handle;
 
-    await products.remove(
-      app, remove_handle
+    await app.api.products.remove(
+      remove_handle
     );
     
     // now query the product's discounts to see if discount was applied to 1st product
-    const related_products = await products.list_related_products(
-      app, pr_upsert.handle
+    const related_products = await app.api.products.list_related_products(
+      pr_upsert.handle
     ) ?? [];
 
     assert.ok(

--- a/packages/test-runner/api_products_variants_test.js
+++ b/packages/test-runner/api_products_variants_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { products } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { App } from '@storecraft/core';
@@ -86,9 +85,9 @@ export const create = app => {
     async () => { 
       assert.ok(app.ready);
       try {
-        await products.remove(app, pr_upsert.handle);
+        await app.api.products.remove(pr_upsert.handle);
         for(const p of var_upsert)
-          await products.remove(app, p.handle);
+          await app.api.products.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;
@@ -103,12 +102,12 @@ export const create = app => {
     await app.db.resources.products.upsert(pr_upsert);
     // upsert all variants
     const ids = await promises_sequence(
-      var_upsert.map(v => () => products.upsert(app, v))
+      var_upsert.map(v => () => app.api.products.upsert(v))
     )
 
     // now query the product's discounts to see if discount was applied to 1st product
-    const product_variants = await products.list_product_variants(
-      app, pr_upsert.handle
+    const product_variants = await app.api.products.list_product_variants(
+      pr_upsert.handle
     );
 
     // console.log(product_variants)
@@ -118,11 +117,11 @@ export const create = app => {
   // return s;
 
   s('remove 2nd variant -> test only one variant for product', async () => {
-    await products.remove(app, var_upsert[0].handle);
+    await app.api.products.remove(var_upsert[0].handle);
     // now query the product's discounts to see if 
     // discount was applied to 1st product
-    const product_variants = await products.list_product_variants(
-      app, pr_upsert.handle
+    const product_variants = await app.api.products.list_product_variants(
+      pr_upsert.handle
     );
 
     // console.log(product_variants)
@@ -134,17 +133,17 @@ export const create = app => {
   });
 
   s('remove product -> confirm all the variants are gone', async () => {
-    await products.remove(app, pr_upsert.handle);
+    await app.api.products.remove(pr_upsert.handle);
     // now query the product's discounts to see if 
     // discount was applied to 1st product
-    const product_variants = await products.list_product_variants(
-      app, pr_upsert.handle
+    const product_variants = await app.api.products.list_product_variants(
+      pr_upsert.handle
     );
     assert.ok(product_variants.length==0, 
       'product removed, but it\'s variants are in place');
 
     const variants_explicit = await Promise.all(
-      var_upsert.map(v => products.get(app, v.handle))
+      var_upsert.map(v => app.api.products.get(v.handle))
     )
     assert.ok(
       variants_explicit.filter(Boolean).length==0, 

--- a/packages/test-runner/api_shipping_crud_test.js
+++ b/packages/test-runner/api_shipping_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { shipping } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { add_sanity_crud_to_test_suite, 
@@ -30,7 +29,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: shipping }
+    { items: items_upsert, app, ops: app.api.shipping }
   );
 
   s.before(
@@ -38,7 +37,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await shipping.remove(app, p.handle);
+          await app.api.shipping.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;

--- a/packages/test-runner/api_shipping_list_test.js
+++ b/packages/test-runner/api_shipping_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { shipping } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -45,7 +44,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: shipping,
+      items: items, app, ops: app.api.shipping,
       resource: 'shipping'
     }
   );
@@ -55,7 +54,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await shipping.remove(app, p.handle);
+          await app.api.shipping.remove(p.handle);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.shipping.upsert(p);

--- a/packages/test-runner/api_storefronts_all_connections_test.js
+++ b/packages/test-runner/api_storefronts_all_connections_test.js
@@ -1,6 +1,4 @@
 import 'dotenv/config';
-import { storefronts, products, collections, 
-  discounts, posts, shipping } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { enums } from '@storecraft/core/v-api';
@@ -134,16 +132,16 @@ export const create = app => {
       assert.ok(app.ready) ;
 
       for(const p of posts_upsert)
-        await posts.remove(app, p.handle);
+        await app.api.posts.remove(p.handle);
       for(const p of discounts_upsert)
-        await discounts.remove(app, p.handle);
+        await app.api.discounts.remove(p.handle);
       for(const p of shipping_upsert)
-        await shipping.remove(app, p.handle);
+        await app.api.shipping.remove(p.handle);
       for(const p of collections_upsert)
-        await collections.remove(app, p.handle);
+        await app.api.collections.remove(p.handle);
       for(const p of products_upsert)
-        await products.remove(app, p.handle);
-      await storefronts.remove(app, storefront_upsert.handle);
+        await app.api.products.remove(p.handle);
+      await app.api.storefronts.remove(storefront_upsert.handle);
     }
   );
 
@@ -152,8 +150,8 @@ export const create = app => {
     const collections_get = await promises_sequence(
       collections_upsert.map(
         c => async () => {
-          await collections.upsert(app, c);
-          return collections.get(app, c.handle);
+          await app.api.collections.upsert(c);
+          return app.api.collections.get(c.handle);
         }
       )
     );
@@ -161,8 +159,8 @@ export const create = app => {
     const products_get = await promises_sequence(
       products_upsert.map(
         c => async () => {
-          await products.upsert(app, c);
-          return products.get(app, c.handle);
+          await app.api.products.upsert(c);
+          return app.api.products.get(c.handle);
         }
       )
     );
@@ -170,8 +168,8 @@ export const create = app => {
     const shipping_get = await promises_sequence(
       shipping_upsert.map(
         c => async () => {
-          await shipping.upsert(app, c);
-          return shipping.get(app, c.handle);
+          await app.api.shipping.upsert(c);
+          return app.api.shipping.get(c.handle);
         }
       )
     );
@@ -179,8 +177,8 @@ export const create = app => {
     const posts_get = await promises_sequence(
       posts_upsert.map(
         c => async () => {
-          await posts.upsert(app, c);
-          return posts.get(app, c.handle);
+          await app.api.posts.upsert(c);
+          return app.api.posts.get(c.handle);
         }
       )
     );
@@ -188,8 +186,8 @@ export const create = app => {
     const discounts_get = await promises_sequence(
       discounts_upsert.map(
         c => async () => {
-          await discounts.upsert(app, c);
-          return discounts.get(app, c.handle);
+          await app.api.discounts.upsert(c);
+          return app.api.discounts.get(c.handle);
         }
       )
     );
@@ -197,13 +195,13 @@ export const create = app => {
 
     // now connect them to storefront
     // upsert products with collections relation
-    await storefronts.upsert(app, storefront_upsert);
-    const storefront_get = await storefronts.get(
-      app, storefront_upsert.handle
-      );
+    await app.api.storefronts.upsert(storefront_upsert);
+    const storefront_get = await app.api.storefronts.get(
+      storefront_upsert.handle
+    );
+
     // now, connect
-    await storefronts.upsert(
-      app,
+    await app.api.storefronts.upsert(
       {
         ...storefront_get, 
         collections: collections_get,
@@ -216,8 +214,8 @@ export const create = app => {
 
     // now verify
     { // verify initial collections
-      const queried = await storefronts.list_storefront_collections(
-        app, storefront_upsert.handle
+      const queried = await app.api.storefronts.list_storefront_collections(
+        storefront_upsert.handle
       );
 
       const verified = collections_upsert.every(
@@ -228,8 +226,8 @@ export const create = app => {
     }
 
     { // verify products
-      const queried = await storefronts.list_storefront_products(
-        app, storefront_upsert.handle
+      const queried = await app.api.storefronts.list_storefront_products(
+        storefront_upsert.handle
       );
 
       const verified = products_upsert.every(
@@ -240,8 +238,8 @@ export const create = app => {
     }
 
     { // verify discounts
-      const queried = await storefronts.list_storefront_discounts(
-        app, storefront_upsert.handle
+      const queried = await app.api.storefronts.list_storefront_discounts(
+        storefront_upsert.handle
       );
 
       const verified = discounts_upsert.every(
@@ -252,8 +250,8 @@ export const create = app => {
     }
 
     { // verify shipping
-      const queried = await storefronts.list_storefront_shipping_methods(
-        app, storefront_upsert.handle
+      const queried = await app.api.storefronts.list_storefront_shipping_methods(
+        storefront_upsert.handle
       );
 
       const verified = shipping_upsert.every(
@@ -264,8 +262,8 @@ export const create = app => {
     }
 
     { // verify posts
-      const queried = await storefronts.list_storefront_posts(
-        app, storefront_upsert.handle
+      const queried = await app.api.storefronts.list_storefront_posts(
+        storefront_upsert.handle
       );
 
       const verified = posts_upsert.every(
@@ -287,15 +285,15 @@ export const create = app => {
       const shipping_id_to_remove = shipping_get.at(0).id;
       const post_id_to_remove = posts_get.at(0).id;
 
-      await collections.remove(app, collection_id_to_remove);
-      await products.remove(app, product_id_to_remove);
-      await discounts.remove(app, discount_id_to_remove);
-      await shipping.remove(app, shipping_id_to_remove);
-      await posts.remove(app, post_id_to_remove);
+      await app.api.collections.remove(collection_id_to_remove);
+      await app.api.products.remove(product_id_to_remove);
+      await app.api.discounts.remove(discount_id_to_remove);
+      await app.api.shipping.remove(shipping_id_to_remove);
+      await app.api.posts.remove(post_id_to_remove);
 
       {
-        let queried = await storefronts.list_storefront_collections(
-          app, storefront_upsert.handle
+        let queried = await app.api.storefronts.list_storefront_collections(
+          storefront_upsert.handle
         );
         assert.not(
           queried.find(q => q.id===collection_id_to_remove), 
@@ -304,9 +302,10 @@ export const create = app => {
       }
       //
       {
-        let queried = await storefronts.list_storefront_discounts(
-          app, storefront_upsert.handle
+        let queried = await app.api.storefronts.list_storefront_discounts(
+          storefront_upsert.handle
         );
+
         assert.not(
           queried.find(q => q.id===discount_id_to_remove), 
           'list discounts does not include original collections !'
@@ -314,8 +313,8 @@ export const create = app => {
       }
       //
       {
-        let queried = await storefronts.list_storefront_posts(
-          app, storefront_upsert.handle
+        let queried = await app.api.storefronts.list_storefront_posts(
+          storefront_upsert.handle
         );
         assert.not(
           queried.find(q => q.id===post_id_to_remove), 
@@ -324,8 +323,8 @@ export const create = app => {
       }
       //
       {
-        let queried = await storefronts.list_storefront_products(
-          app, storefront_upsert.handle
+        let queried = await app.api.storefronts.list_storefront_products(
+          storefront_upsert.handle
         );
         assert.not(
           queried.find(q => q.id===product_id_to_remove), 
@@ -334,8 +333,8 @@ export const create = app => {
       }
       //
       {
-        let queried = await storefronts.list_storefront_shipping_methods(
-          app, storefront_upsert.handle
+        let queried = await app.api.storefronts.list_storefront_shipping_methods(
+          storefront_upsert.handle
         );
         assert.not(
           queried.find(q => q.id===shipping_id_to_remove), 

--- a/packages/test-runner/api_storefronts_crud_test.js
+++ b/packages/test-runner/api_storefronts_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { storefronts } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { add_sanity_crud_to_test_suite, 
@@ -30,7 +29,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: storefronts }
+    { items: items_upsert, app, ops: app.api.storefronts }
   );
 
   s.before(
@@ -38,7 +37,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await storefronts.remove(app, p.handle);
+          await app.api.storefronts.remove(p.handle);
       } catch(e) {
         console.log(e)
         throw e;

--- a/packages/test-runner/api_storefronts_list_test.js
+++ b/packages/test-runner/api_storefronts_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { storefronts } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -7,7 +6,6 @@ import { create_handle, file_name,
   get_static_ids} from './api.utils.crud.js';
 import { App } from '@storecraft/core';
 import esMain from './utils.esmain.js';
-import { compute_count_of_query } from '@storecraft/core/v-api/con.statistics.logic.js';
 
 const handle = create_handle('sf', file_name(import.meta.url));
 
@@ -48,7 +46,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: storefronts, 
+      items: items, app, ops: app.api.storefronts, 
       resource: 'storefronts' 
     }
   );
@@ -58,7 +56,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await storefronts.remove(app, p.id);
+          await app.api.storefronts.remove(p.id);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.storefronts.upsert(p);

--- a/packages/test-runner/api_tags_crud_test.js
+++ b/packages/test-runner/api_tags_crud_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { tags } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { assert_async_throws } from './utils.js';
@@ -34,7 +33,7 @@ export const create = app => {
 
   const s = suite(
     file_name(import.meta.url), 
-    { items: items_upsert, app, ops: tags }
+    { items: items_upsert, app, ops: app.api.tags }
   );
 
   s.before(
@@ -42,7 +41,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items_upsert)
-          await tags.remove(app, p.handle);
+          await app.api.tags.remove(p.handle);
       } catch(e) {
         // console.log(e)
         throw e;
@@ -61,13 +60,13 @@ export const create = app => {
       handle: 'tag 2', values:['a', 'b']
     }
     await assert_async_throws(
-      async () => await tags.upsert(app, {
+      async () => await app.api.tags.upsert({
         handle: 'tag 2', values: ['a', 'b']
       })
     );
 
     await assert_async_throws(
-      async () => await tags.upsert(app, {
+      async () => await app.api.tags.upsert({
         handle: 'tag-2', values: ['a c', 'b']
       })
     );

--- a/packages/test-runner/api_tags_list_test.js
+++ b/packages/test-runner/api_tags_list_test.js
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { tags } from '@storecraft/core/v-api';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { create_handle, file_name, 
@@ -45,7 +44,7 @@ export const create = app => {
   const s = suite(
     file_name(import.meta.url), 
     { 
-      items: items, app, ops: tags,
+      items: items, app, ops: app.api.tags,
       resource: 'tags'
     }
   );
@@ -55,7 +54,7 @@ export const create = app => {
       assert.ok(app.ready) 
       try {
         for(const p of items) {
-          await tags.remove(app, p.handle);
+          await app.api.tags.remove(p.handle);
           // we bypass the api and upsert straight
           // to the db because we control the time-stamps
           await app.db.resources.tags.upsert(p);

--- a/packages/test-runner/play.js
+++ b/packages/test-runner/play.js
@@ -9,8 +9,8 @@ export const create_app = async () => {
   let app = new App(
     new NodePlatform(),
     new MongoDB({ db_name: 'test'}),
-    null, null, null, {
-      admins_emails: [admin_email],
+    null, null, null, null, {
+      auth_admins_emails: [admin_email],
     }
   );
   


### PR DESCRIPTION
This is a major refactor:
- `v-api` is now an interfacr in the storecraft app as opposed to
 a tree shakable exports. This is more intuitive for users as a library
- performance tests indicate that performance has not degraded
- I had to refactor the way tests consume the api