### PR TITLE
Core storage rewrite urls

### DIFF
--- a/packages/core/v-api/con.storage.logic.js
+++ b/packages/core/v-api/con.storage.logic.js
@@ -1,3 +1,4 @@
+import { App } from "../index.js"
 
 /**
  * prefer signed url get by default
@@ -8,3 +9,69 @@ export const does_prefer_signed = search_params => {
 }
 
 
+/**
+ * @param {App} app 
+ */
+export const rewrite_media = (app) =>
+/**
+ * Recursively go over object keys, locate `media` keys, iterate
+ * them if they are `arrays` and replace `storage://` values with 
+ * **CDN** rewrites.
+ * 
+ * @param {any} o 
+ */
+(o) => {
+
+  if(!app.config.storage_rewrite_urls)
+    return;
+
+  /** @type {URL} */
+  let url;
+
+  try { // testing malformness
+    url = new URL(app.config.storage_rewrite_urls);
+  } catch (e) {
+    return;
+  }
+
+  rewrite_object(o, url.href);
+}
+
+
+/**
+ * 
+ * @param {string[]} media 
+ * @param {string} rewrite 
+ */
+const rewrite_media_array = (media, rewrite) => {
+  return media.map(
+    media_url => {
+      if(typeof media_url === 'string') {
+        return media_url.replace('storage://', rewrite)
+      }
+      return media_url;
+    }
+  )
+}
+
+
+/**
+ * 
+ * @param {object} item 
+ * @param {string} rewrite 
+ */
+const rewrite_object = (item, rewrite) => {
+  if(!item || typeof item !== 'object')
+    return;
+
+  for(const [key, value] of Object.entries(item)) {
+
+    if(key==='media') {
+      if(Array.isArray(value)) {
+        item[key] = rewrite_media_array(value, rewrite);
+      }
+    } else {
+      rewrite_object(value, rewrite);
+    }
+  }
+}

--- a/packages/core/v-api/con.storage.logic.js
+++ b/packages/core/v-api/con.storage.logic.js
@@ -10,13 +10,15 @@ export const does_prefer_signed = search_params => {
 
 
 /**
- * @param {App} app 
- */
-export const rewrite_media = (app) =>
-/**
  * Recursively go over object keys, locate `media` keys, iterate
  * them if they are `arrays` and replace `storage://` values with 
  * **CDN** rewrites.
+ * 
+ * 
+ * @param {App} app 
+ */
+export const rewrite_media_from_storage = (app) =>
+/**
  * 
  * @param {any} o 
  */
@@ -34,20 +36,62 @@ export const rewrite_media = (app) =>
     return;
   }
 
-  rewrite_object(o, url.href);
+  let href = url.href;
+  if(!url.href.endsWith('/'))
+    href += '/';
+
+  rewrite_object(o, 'storage://', href);
+}
+
+/**
+ * Recursively go over object keys, locate `media` keys, iterate
+ * them if they are `arrays` and replace `app.config.storage_rewrite_urls`
+ * into `storage://` 
+ * 
+ * 
+ * @param {App} app 
+ */
+export const rewrite_media_to_storage = (app) =>
+/**
+ * 
+ * @param {any} o 
+ */
+(o) => {
+
+  if(!app.config.storage_rewrite_urls)
+    return;
+
+  /** @type {URL} */
+  let url;
+
+  try { // testing malformness
+    url = new URL(app.config.storage_rewrite_urls);
+  } catch (e) {
+    return;
+  }
+
+  let href = url.href;
+  if(!url.href.endsWith('/'))
+    href += '/';
+
+  rewrite_object(o, href, 'storage://');
 }
 
 
 /**
  * 
  * @param {string[]} media 
- * @param {string} rewrite 
+ * @param {string} rewrite_from 
+ * @param {string} rewrite_to 
  */
-const rewrite_media_array = (media, rewrite) => {
+const rewrite_media_array = (media, rewrite_from, rewrite_to) => {
   return media.map(
     media_url => {
-      if(typeof media_url === 'string') {
-        return media_url.replace('storage://', rewrite)
+      if(
+        (typeof media_url === 'string') &&
+        (media_url.startsWith(rewrite_from))
+      ) {
+        return media_url.replace(rewrite_from, rewrite_to)
       }
       return media_url;
     }
@@ -58,9 +102,10 @@ const rewrite_media_array = (media, rewrite) => {
 /**
  * 
  * @param {object} item 
- * @param {string} rewrite 
+ * @param {string} rewrite_from 
+ * @param {string} rewrite_to 
  */
-const rewrite_object = (item, rewrite) => {
+const rewrite_object = (item, rewrite_from, rewrite_to) => {
   if(!item || typeof item !== 'object')
     return;
 
@@ -68,10 +113,10 @@ const rewrite_object = (item, rewrite) => {
 
     if(key==='media') {
       if(Array.isArray(value)) {
-        item[key] = rewrite_media_array(value, rewrite);
+        item[key] = rewrite_media_array(value, rewrite_from, rewrite_to);
       }
     } else {
-      rewrite_object(value, rewrite);
+      rewrite_object(value, rewrite_from, rewrite_to);
     }
   }
 }

--- a/packages/core/v-rest/con.storage.routes.js
+++ b/packages/core/v-rest/con.storage.routes.js
@@ -27,7 +27,6 @@ export const create_routes = (app) => {
   polka.get(
     '/',
     async (req, res) => {
-      console.log('features')
       res.sendJson(features);
     }
   );

--- a/packages/dashboard/src/admin/comps/media.jsx
+++ b/packages/dashboard/src/admin/comps/media.jsx
@@ -466,18 +466,22 @@ const Media = (
 
       // upload here
       try {
+        const key = `images/${name}`;
         const ok = await sdk.storage.putBytes(
-          `images/${name}`, blob
+          key, blob
         );
 
         if(!ok) throw 'wow';
-        const url = `storage://images/${name}`
+
+        const url = `storage://${key}`
         const us = [url, ...urls]                        ;
+
         setUrls(us);
         onChange && onChange(us);
 
         setUploads(ups => ups.filter(up => up.id!==id));
         URL.revokeObjectURL(obj_url);
+        
       } catch (err) {
         console.log(err);
         setUploads(

--- a/packages/database-sql-base/src/con.images.js
+++ b/packages/database-sql-base/src/con.images.js
@@ -1,15 +1,15 @@
 import { func } from '@storecraft/core/v-api'
 import { SQL } from '../driver.js'
 import { count_regular, delete_me, delete_search_of, 
-  insert_entity_array_values_of, 
   insert_search_of, regular_upsert_me, where_id_or_handle_table 
 } from './con.shared.js'
 import { sanitize_array, sanitize } from './utils.funcs.js'
 import { query_to_eb, query_to_sort } from './utils.query.js'
-// import { ID } from '@storecraft/core/v-api/utils.func.js'
 import { Transaction } from 'kysely'
 import { ID } from '@storecraft/core/v-api/utils.func.js'
-import { image_url_to_handle, image_url_to_name } from '@storecraft/core/v-api/con.images.logic.js'
+import { 
+  image_url_to_handle, image_url_to_name 
+} from '@storecraft/core/v-api/con.images.logic.js'
 
 /**
  * @typedef {import('@storecraft/core/v-database').db_images} db_col

--- a/packages/playground/index.js
+++ b/packages/playground/index.js
@@ -20,6 +20,9 @@ let app = new App(
   ,
   {
     'paypal_standard': new PaypalStandard({ client_id: 'blah', secret: 'blah 2', env: 'prod' })
+  }, null, null, 
+  {
+    storage_rewrite_urls: undefined
   }
 );
 


### PR DESCRIPTION
This may be a fine feature for some folks, this feature will:
- let a user setup a CDN url
- Upon fetching media urls: `storage://...` -> `CDN url`
- Upon upsert media urls: `CDN url` -> `storage://...` 

The reason, we rewrite back and forth upon fetching and upserting is because
of an over simple architecture of media urls at the backend. This way, if the
dashboard get a rewritten url and then upserts an item, it will not be changed forever,
therefore, if one changes a CDN, he will not need to worry.

This is of course not perfect, but it suits our vision of simplicity is
better than over engineering to catch that 1% scenario.

A better way is to keep urls as are `storage://images/a.png` and just translate it at your frontend
because you already know the url.
