### PR TITLE
dashboard: bling refactor

### DIFF
--- a/packages/dashboard/pages/logo.jsx
+++ b/packages/dashboard/pages/logo.jsx
@@ -7,7 +7,7 @@ const Logo = () => {
   return (
 <div className='w-[512px] h-[512px] bg-slate-100 p-3'>
 
-  <Bling className='w-full h-full' stroke='p-3'
+  <Bling className='w-full h-full' stroke='border-[12px]'
           from='from-pink-500 dark:from-pink-500' 
           to='to-kf-600 dark:to-kf-500'>
     <div className='w-full h-full bg-slate-100 rounded-3xl shadow-xl

--- a/packages/dashboard/src/admin/apps/gallery/gallery-searchbar.jsx
+++ b/packages/dashboard/src/admin/apps/gallery/gallery-searchbar.jsx
@@ -68,7 +68,7 @@ const SearchBar = forwardRef(
           className='text-2xl w-fit font-mono min-w-[5rem]'/>
 
     <BlingInput 
-        className='m-1 flex-1 max-w-[30rem] h-12' stroke='p-0'
+        className='m-1 flex-1 max-w-[30rem] h-12' stroke='border-none'
         type='search' placeholder={searchTitle} 
         value={search}
         onChange={e => setSearch(e.currentTarget.value)} 

--- a/packages/dashboard/src/admin/apps/gallery/gallery.jsx
+++ b/packages/dashboard/src/admin/apps/gallery/gallery.jsx
@@ -58,7 +58,7 @@ const Gallery = (
 
   return (
 <div className={`flex flex-col justify-between ${className}`} {...rest} >
-  <Bling stroke='p-[1px]' rounded='rounded-md' 
+  <Bling rounded='rounded-md' 
          className='shadow-md w-full h-fit' >
     <SearchBar 
         ref={ref_actions} 
@@ -74,7 +74,6 @@ const Gallery = (
       onClickImage={onClickImage} />   
   <ShowIf show={pages?.length} >
     <Bling 
-        stroke='p-[1px]' 
         rounded='rounded-md' 
         className='mt-5 shadow-md w-full h-fit' >
       <BottomActions 

--- a/packages/dashboard/src/admin/apps/gallery/image-page.jsx
+++ b/packages/dashboard/src/admin/apps/gallery/image-page.jsx
@@ -163,7 +163,7 @@ const ImagePage = ({}) => {
     <Card className='mt-10' error={error}>
       <div className='flex flex-col gap-10'>
         <div className='self-end'>
-          <Bling stroke='p-0.5' className='w-fit h-fit' rounded='rounded-full'>
+          <Bling stroke='border-2' className='w-fit h-fit' rounded='rounded-full'>
             <LoadingButton 
                 className='h-6 px-2 
                 bg-slate-50 dark:bg-slate-800 

--- a/packages/dashboard/src/admin/comps/attributes.jsx
+++ b/packages/dashboard/src/admin/comps/attributes.jsx
@@ -49,7 +49,6 @@ const Attr = (
     
 <Bling 
     className={`shadow-md shadow-slate-300 dark:shadow-slate-800 ${className}`} 
-    stroke='p-px' 
     rounded='rounded-lg'>
   <div className='w-full relative rounded-lg
                   shelf-bling-fill
@@ -59,7 +58,7 @@ const Attr = (
     <p children='Key' className=''/>
     <BlingInput 
         className='mt-1' 
-        stroke='pb-px'
+        stroke='border-b'
         onChange={e => onChangeInternal('key', e)}
         value={val.key}
         placeholder='attribute key' 
@@ -67,7 +66,7 @@ const Attr = (
 
     <p children='Value' className='mt-3'/>
     <BlingInput 
-        className='mt-1' stroke='pb-px'
+        className='mt-1' stroke='border-b'
         onChange={e => onChangeInternal('value', e)}
         value={val.value}
         placeholder='attribute value' 

--- a/packages/dashboard/src/admin/comps/browse-collection.jsx
+++ b/packages/dashboard/src/admin/comps/browse-collection.jsx
@@ -95,7 +95,7 @@ const BrowseCollection = (
       onFocus={() => setFocus(true)} 
       tabIndex={4344}>
         
-    <Bling rounded='rounded-xl' stroke='p-0.5' >
+    <Bling rounded='rounded-xl' stroke='border-2' >
       <div className='flex flex-row justify-between items-center'>
         <input ref={ref_input} type='search' 
           placeholder='search' 
@@ -146,12 +146,12 @@ const BrowseCollection = (
       </div>
       <div className='self-end flex flex-row gap-5'>
         <BlingButton 
-            stroke='p-0.5' 
+            stroke='border-2' 
             className='opacity-60' 
             children='cancel' 
             onClick={onCancel} />
         <BlingButton 
-            stroke='p-0.5' 
+            stroke='border-2' 
             children='save' 
             onClick={() => onSave(selected)} />
       </div>

--- a/packages/dashboard/src/admin/comps/collection-actions.jsx
+++ b/packages/dashboard/src/admin/comps/collection-actions.jsx
@@ -62,7 +62,7 @@ export const TopActions = forwardRef(
     <Link to={createLink} draggable='false' className="m-2">
       <BlingButton2
           className='h-9 w-16 text-base rounded-lg' 
-          stroke='p-0.5' children='add'
+          stroke='border-2' children='add'
           icon={
             <IoCreateOutline 
                 className='inline shelf-text-label-color 
@@ -72,7 +72,7 @@ export const TopActions = forwardRef(
     </Link>            
     <BlingInput 
         className='m-1 flex-1 h-fit max-w-[20rem]' 
-         stroke='p-px' rounded='rounded-md'
+         rounded='rounded-md'
          type='search' placeholder={searchTitle} 
          value={search ?? ''}
          onChange={e => setSearch(e.currentTarget.value)} 

--- a/packages/dashboard/src/admin/comps/common-button.jsx
+++ b/packages/dashboard/src/admin/comps/common-button.jsx
@@ -176,7 +176,7 @@ export const PromisableLoadingButton = (
 export const PromisableLoadingBlingButton = (
   {
     onClick, show=true, className='h-6', loading: $loading, 
-    stroke='p-px', rounded='rounded-full', 
+    stroke='border', rounded='rounded-full', 
     from='from-pink-300 dark:from-pink-500',
     to='to-kf-300 dark:to-kf-500',
     ...rest
@@ -221,7 +221,7 @@ export const PromisableLoadingBlingButton = (
  */
 export const BlingButton = (
   { 
-    from, to, rounded='rounded-lg', stroke='p-0.5', 
+    from, to, rounded='rounded-lg', stroke='border-2', 
     children, text='what', className='h-10', 
     btnClassName='', ...rest 
   }

--- a/packages/dashboard/src/admin/comps/common-ui.jsx
+++ b/packages/dashboard/src/admin/comps/common-ui.jsx
@@ -224,6 +224,28 @@ export const BlingInput = forwardRef(
 )
 
 /**
+ * 
+ * @param {string[]} color_stops 
+ * @returns 
+ */
+export const border_bling_style = (color_stops=['#efefec', '#973cff']) => {
+
+  return {
+    style: {
+      'background-image': `linear-gradient(white, white), linear-gradient(to right, ${color_stops.join(',')})`,
+      'background-clip': 'padding-box, border-box',
+      'border-color': 'transparent',
+      'background-origin': 'padding-box, border-box',
+      // 'background-color': 'light-dark(#ccc, #333)'
+    }
+  }
+}
+
+
+// 
+/**
+ * Background container with gradient
+ * 
  * @typedef {{
  *  className?: string, rounded?: string, 
  *  children?: any, stroke?: string, from?: string, 
@@ -239,11 +261,23 @@ export const BlingInput = forwardRef(
 export const Bling = ( 
   { 
     className, rounded='rounded-md', 
-    children, stroke='p-px', 
+    children, stroke='border', 
     from='from-pink-500 dark:from-pink-500', 
     to='to-kf-500 dark:to-kf-500', ...rest 
   }
 ) => {
+
+  return (
+<div className={`bg-gradient-to-r ${from} ${to} ${stroke} 
+                ${rounded} ${className}`} {...rest}
+      style={{
+  'background-clip': 'border-box',
+  'border-color': 'transparent',
+  'background-origin': 'border-box'
+      }}>
+{ children }
+</div>    
+  )
 
   return (
 <div className={`bg-gradient-to-r ${from} ${to} ${stroke} 

--- a/packages/dashboard/src/admin/comps/discount-details.jsx
+++ b/packages/dashboard/src/admin/comps/discount-details.jsx
@@ -150,7 +150,7 @@ const BulkDiscount = ({ type, value, onChange }) => {
             )
           }
         inputClsName='h-7'
-        stroke='pb-px'
+        stroke='border-b'
         className='rounded-md w-14'/>
     <p>
       <Dashed>products</Dashed> specified by the filters <b>ABOVE ⬆️</b> 
@@ -618,7 +618,7 @@ const BuyXGetYDiscount = ({ type, value, onChange }) => {
             )
           }
         inputClsName='h-7'
-        stroke='pb-px'
+        stroke='border-b'
         className='rounded-md w-14 inline-block'/>
     <p>
       <Dashed>products</Dashed> specified by the filters <b>ABOVE ⬆️</b> 
@@ -644,7 +644,7 @@ const BuyXGetYDiscount = ({ type, value, onChange }) => {
             Math.max(parseInt(e.currentTarget.value), 1)
             )
           }
-        stroke='pb-px'
+        stroke='border-b'
         rounded='rounded-md'
         className='w-14'/>
     <p>

--- a/packages/dashboard/src/admin/comps/discount-filters.jsx
+++ b/packages/dashboard/src/admin/comps/discount-filters.jsx
@@ -187,7 +187,7 @@ const Filter_ProductHasHandle = ( { onChange, value=[] } ) => {
 <div className='w-full'>
   <BlingButton 
         className='text-sm mx-auto h-10 w-40 ' 
-        stroke='p-0.5'
+        stroke='border-2'
         children='Browse products' 
         onClick={() => ref_overlay.current.show()} />
   <Overlay ref={ref_overlay} >
@@ -470,7 +470,7 @@ const Filter_OrderHasCustomers = ( { onChange, value=[] } ) => {
   <BlingButton 
       children='Browse Customers' 
       className='text-sm mx-auto h-10 w-40' 
-      stroke='p-0.5'
+      stroke='border-2'
       onClick={() => ref_overlay.current.show()} />
 
   <Overlay ref={ref_overlay} >

--- a/packages/dashboard/src/admin/comps/document-actions.jsx
+++ b/packages/dashboard/src/admin/comps/document-actions.jsx
@@ -92,7 +92,7 @@ return (
     </div>
     <ShowIf show={Boolean(onClickDelete)}>
 
-      <Bling stroke='p-0.5' className='h-fit' rounded='rounded-full'>
+      <Bling stroke='border-2' className='h-fit' rounded='rounded-full'>
         <LoadingButton 
             className='h-6 px-2 
             bg-slate-50 dark:bg-slate-800 

--- a/packages/dashboard/src/admin/comps/error-message.jsx
+++ b/packages/dashboard/src/admin/comps/error-message.jsx
@@ -54,7 +54,7 @@ const ErrorMessage = (
   return (
 <div className={cls}>
   <Bling 
-      stroke='p-[2px] dark:p-[1px] mt-5' 
+      stroke='border-2 dark:border mt-5' 
       rounded='rounded-lg' >
     <div 
         className=' relative rounded-md dark:rounded-lg bg-gradient-to-br 

--- a/packages/dashboard/src/admin/comps/home-performace.jsx
+++ b/packages/dashboard/src/admin/comps/home-performace.jsx
@@ -190,7 +190,7 @@ const TopSoldCard = (
 ) => {
 
   return (
-<Bling rounded='rounded-xl' stroke='p-[2px]'>
+<Bling rounded='rounded-xl' stroke='border-2'>
   <div className='w-56 h-52 
                 shelf-plain-card-fill
                 rounded-xl shadow-xl dark:shadow-xl px-3 pt-2

--- a/packages/dashboard/src/admin/comps/home-stat-card.jsx
+++ b/packages/dashboard/src/admin/comps/home-stat-card.jsx
@@ -53,7 +53,7 @@ const StatCard = (
     className='cursor-pointer' 
     draggable='false'>
   <Bling 
-      stroke='p-0.5' 
+      stroke='border-2' 
       rounded='rounded-lg'
       className='w-fit shadow-md hover:scale-105 
                 transition-transform'>

--- a/packages/dashboard/src/admin/comps/login-form.jsx
+++ b/packages/dashboard/src/admin/comps/login-form.jsx
@@ -84,7 +84,7 @@ const LoginForm = (
  return (
 <div className={className}>
  <Bling className='shadow-lg shadow-gray-300'
-        stroke='p-1' to='to-kf-400'>
+        stroke='border-4' to='to-kf-400'>
    <form className='w-full p-5 bg-white flex flex-col text-sm 
                      tracking-wider font-medium gap-5 rounded-md'
          onSubmit={onSubmit}>
@@ -100,7 +100,7 @@ const LoginForm = (
          value={credentials} 
          onChange={onChange}  autoComplete='on' 
          name='password' />
-     <Bling stroke='p-1 w-full' from='from-kf-500' to='to-pink-400'>
+     <Bling stroke='border-4 w-full' from='from-kf-500' to='to-pink-400'>
        <input 
            type='submit' value='LOGIN' 
            title='Login' alt='Login'

--- a/packages/dashboard/src/admin/comps/login-marquee.jsx
+++ b/packages/dashboard/src/admin/comps/login-marquee.jsx
@@ -57,7 +57,7 @@ const Capsule = ({}) => {
 
   return (
 <Bling 
-    rounded='rounded-full' stroke='p-0.5' 
+    rounded='rounded-full' stroke='border-2' 
     from='from-pink-400' to='to-pink-500'>
   <div 
       className='rounded-full my-auto bg-kf-800 w-fit text-sm

--- a/packages/dashboard/src/admin/comps/markdown-card.jsx
+++ b/packages/dashboard/src/admin/comps/markdown-card.jsx
@@ -28,7 +28,7 @@ return (
    desc={description}
    border={true} 
    {...rest}>
- <Bling stroke='pb-px' rounded='rounded-lg' >
+ <Bling stroke='border-b' rounded='rounded-lg' >
    <MDView
        className='rounded-md p-3 
          w-full text-base min-h-8 align-middle

--- a/packages/dashboard/src/admin/comps/modal.jsx
+++ b/packages/dashboard/src/admin/comps/modal.jsx
@@ -94,12 +94,12 @@ const Modal = forwardRef(
           className='text-red-500 text-base break-words' />
       <div className='flex flex-row justify-between mt-10 text-base'>
         <BlingButton 
-            stroke='pb-0.5' 
+            stroke='border-b-2' 
             btnClassName='rounded-none'
             rounded='rounded-none'
             children='No' 
             onClick={() => ref.current.hide()} />
-        <BlingButton stroke='pb-0.5' 
+        <BlingButton stroke='border-b-2' 
             btnClassName='rounded-none'
             rounded='rounded-none'
             children='Yes' 

--- a/packages/dashboard/src/admin/comps/order-coupon-info.jsx
+++ b/packages/dashboard/src/admin/comps/order-coupon-info.jsx
@@ -86,7 +86,7 @@ const OrderCouponInfo = (
     <BlingInput ref={ref_name} rounded='rounded-md'
             placeholder='coupon' type='text' 
             className='mt-1'/>
-    <BlingButton className='mt-1 ml-3 h-10 flex-1' stroke='p-0.5'
+    <BlingButton className='mt-1 ml-3 h-10 flex-1' stroke='border-2'
           children='Add' onClick={onManualAdd} />
   </div>
   <HR className='mt-5'/>

--- a/packages/dashboard/src/admin/comps/order-line-items.jsx
+++ b/packages/dashboard/src/admin/comps/order-line-items.jsx
@@ -84,7 +84,7 @@ const LineitemsTable =
               className='py-2 w-14 pr-3'/>
 
           <td className='py-2 w-14 pr-3'>
-            <Bling stroke='pb-0.5' className='w-full '>
+            <Bling stroke='border-b-2' className='w-full '>
               <input 
                   placeholder='' 
                   value={it.qty} type='number' 

--- a/packages/dashboard/src/admin/comps/product-related-products.jsx
+++ b/packages/dashboard/src/admin/comps/product-related-products.jsx
@@ -103,7 +103,7 @@ const RelatedProducts = (
   return (
 <div {...rest}>
   <BlingButton children='Browse products'
-      stroke='p-0.5'
+      stroke='border-2'
       className='w-40 h-10 mx-auto'  
       onClick={() => ref_overlay.current.show()} />
   <Overlay ref={ref_overlay} >

--- a/packages/dashboard/src/admin/comps/products-in-collection.jsx
+++ b/packages/dashboard/src/admin/comps/products-in-collection.jsx
@@ -196,7 +196,7 @@ const ProductsInCollection = ({ value, context }) => {
             className='text-gray-500 text-sm w-fit mx-auto 
                         shadow-gray-800/25 shadow-lg hover:scale-110 
                         transition-transform cursor-pointer' 
-            stroke='p-0.5' rounded='rounded-full'
+            stroke='border-2' rounded='rounded-full'
             from='from-pink-500' to='to-kf-400'
             onClick={() => !loading && ref_overlay.current.show()}>
           <IoMdAdd className={'text-4xl text-white ' + 

--- a/packages/dashboard/src/admin/comps/products-variants.jsx
+++ b/packages/dashboard/src/admin/comps/products-variants.jsx
@@ -116,7 +116,7 @@ const ProductOption = (
           inputClsName='text-base px-1 shelf-card w-full rounded-md h-10' 
           overrideClass={true}
           type='text' className='mt-1 flex-1' 
-          rounded='rounded-md' stroke='pb-px' /> 
+          rounded='rounded-md' stroke='border-b' /> 
       <BlingButton 
           children='add' className='h-10 ' 
           onClick={onClickAddOptionValue} />

--- a/packages/dashboard/src/admin/comps/settings-storage.jsx
+++ b/packages/dashboard/src/admin/comps/settings-storage.jsx
@@ -58,7 +58,7 @@ const FirebaseStorage = ({ onChange, params }) => {
       (it, ix) => (
         <div className='flex flex-col gap-1' key={ix}>
           <p children={it.name} />
-          <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='pb-px' 
+          <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='border-b' 
                       value={it.value ?? params?.[it.key] ?? ''}
                       inputClsName='h-8 w-full' 
                       className='w-full' 
@@ -125,7 +125,7 @@ const CloudflareStorage = ({ onChange, params }) => {
     (it, ix) => (
       <div className='flex flex-col gap-1' key={ix}>
         <p children={it.name} />
-        <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='pb-px' 
+        <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='border-b' 
                     value={it.value ?? params?.[it.key] ?? ''}
                     inputClsName='h-8 w-full' 
                     className='w-full' 
@@ -192,7 +192,7 @@ const AWSS3Storage = ({ onChange, params }) => {
     (it, ix) => (
       <div className='flex flex-col gap-1' key={ix}>
         <p children={it.name} />
-        <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='pb-px' 
+        <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='border-b' 
                     value={it.value ?? params?.[it.key] ?? ''}
                     inputClsName='h-8 w-full' 
                     className='w-full' 
@@ -255,7 +255,7 @@ const S3CompatibleStorage = ({ onChange, params }) => {
       (it, ix) => (
         <div className='flex flex-col gap-1' key={ix}>
           <p children={it.name} />
-          <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='pb-px' 
+          <BlingInput placeHolder={it.placeHolder ?? it.name} stroke='border-b' 
                       value={it.value ?? params?.[it.key] ?? ''}
                       inputClsName='h-8 w-full' 
                       className='w-full' 

--- a/packages/dashboard/src/admin/comps/tag-values.jsx
+++ b/packages/dashboard/src/admin/comps/tag-values.jsx
@@ -73,7 +73,7 @@ const TagValues = (
         ref={ref} type='text'/>
 
     <BlingButton 
-        children='Add' stroke='p-0.5 h-10' 
+        children='Add' stroke='border-2 h-10' 
         onClick={onAdd}/>
   </div>
   <CapsulesView 

--- a/packages/dashboard/src/admin/layout.jsx
+++ b/packages/dashboard/src/admin/layout.jsx
@@ -144,7 +144,7 @@ const Layout = (
       <Bling 
           className='my-3 ml-3 shadow-sm' 
           rounded='rounded-tr-3xl rounded-tl-md rounded-br-3xl' 
-          stroke='pr-px pt-1 pb-4' 
+          stroke='border-r pt-1 border-b-[16px]' 
           from='from-kf-400 dark:from-kf-500' 
           to='to-pink-400 dark:to-pink-500'>
         <SideMenu 

--- a/packages/dashboard/src/admin/pages/collection.jsx
+++ b/packages/dashboard/src/admin/pages/collection.jsx
@@ -126,9 +126,11 @@ const Actions = (
       onClickReload={onClickReload}
       onClickSave={onClickSave}>
     <PromisableLoadingBlingButton 
-        Icon={<MdPublish />} text='publish' 
+        Icon={<MdPublish />} 
+        text='publish' 
         show={Boolean(onClickPublish)}
-        onClick={onClickPublish} className='' />
+        onClick={onClickPublish} 
+        className='' />
   </RegularDocumentActions>  
   )
 }

--- a/packages/dashboard/tailwind.config.mjs
+++ b/packages/dashboard/tailwind.config.mjs
@@ -14,6 +14,7 @@ const config = {
 		"./src/comps/**/*.{js,ts,jsx,tsx}",
 		"./src/admin/**/*.{js,ts,jsx,tsx}",
 		"./src/docs/**/*.{js,ts,jsx,tsx}",
+		"./styles/*.scss",
 	  ],
 	theme: {
 		screens: screens,


### PR DESCRIPTION
This pr refactors some of the bling classes because it used to rely on `padding`,
which does not render well with sub pixels upon zooming in browsers.

This instead uses the border property with some clever clipping, and it works with
`tailwindCSS` and supports dark mode