### PR TITLE
core, rest: configure cors

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -105,7 +105,7 @@ export class App {
   /** 
    * @description The REST API controller
    * 
-   * @type {ReturnType<create_rest_api>} 
+   * @type {ReturnType<typeof create_rest_api>} 
    */ 
   #_rest_controller;
 

--- a/packages/core/v-api/types.api.d.ts
+++ b/packages/core/v-api/types.api.d.ts
@@ -1,4 +1,5 @@
 import { db_driver } from "../v-database/types.public.js";
+import { CORSOptions } from "../v-polka/cors.js";
 
 /**
  * 
@@ -107,6 +108,12 @@ export type StorecraftConfig = {
    */
   storage_rewrite_urls?: string;
 
+  /**
+   * @description (Optional) Your chance to override the default `CORS` config
+   * for HTTP requests
+   * 
+   */
+  cors?: CORSOptions;
 }
 
 

--- a/packages/core/v-polka/cors.js
+++ b/packages/core/v-polka/cors.js
@@ -27,7 +27,7 @@ export const CORSDefault = {
 export const cors = (options) => {
   const opts = {
     ...CORSDefault,
-    ...options,
+    ...(options ?? {}),
   }
 
   const findAllowOrigin = ((optsOrigin) => {
@@ -44,8 +44,8 @@ export const cors = (options) => {
   })(opts.origin);
 
   /**
-   * @param {import("./index.js").ApiRequest} req
-   * @param {import("./index.js").ApiResponse} res
+   * @param {import("../types.public.js").ApiRequest} req
+   * @param {import("../types.public.js").ApiResponse} res
    */
   return async function cors(req, res) {
 

--- a/packages/core/v-rest/index.js
+++ b/packages/core/v-rest/index.js
@@ -31,6 +31,14 @@ import { cors } from "../v-polka/cors.js";
 
 
 /**
+ * 
+ * @typedef {object} RestApiConfig
+ * @prop {import("../v-polka/cors.js").CORSOptions} cors
+ * 
+ */
+
+
+/**
  * @description Create the entire virtual API with lazy 
  * loading which is great for serverless
  * 
@@ -40,12 +48,13 @@ import { cors } from "../v-polka/cors.js";
  * @param {import("../types.public.js").App<
  *  PlatformNativeRequest, PlatformContext, any, any, any, any, any
  * >} app
+ * @param {RestApiConfig} config
  */
-export const create_rest_api = (app) => {
+export const create_rest_api = (app, config) => {
   // This is the main / root router
   const polka = new Polka();
 
-  polka.use(cors());
+  polka.use(cors(config?.cors));
   polka.use(json());
 
   const lazy_creator = new class {


### PR DESCRIPTION
Now, `cors` for rest-api can be configured easily for each app