### PR TITLE
db: resolve ESM module import path issues on Windows

### DIFF
--- a/packages/databases/database-sql-base/migrate.js
+++ b/packages/databases/database-sql-base/migrate.js
@@ -3,7 +3,7 @@
  * @import { SqlDialectType } from './types.public.js';
  * @import { Migration } from 'kysely';
  */
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as path from 'path'
 import { promises as fs } from 'fs'
 import {
@@ -38,7 +38,9 @@ export const get_migrations = async (dialect_type='SQLITE') => {
   for (const file of files) {
     if(file.endsWith('.js')) {
       const file_name = file.split('.').slice(0, -1).join('.');
-      const migration = await import(path.join(__dirname, folder, file));
+      const file_path = path.join(__dirname, folder, file);
+      const file_url = pathToFileURL(file_path);
+      const migration = await import(file_url.href);
       migrations[file_name] = migration;
     }
   }


### PR DESCRIPTION
**Scenario:**
After creating a project with `npx storecraft create`, running `npm run migrate` throws an error.
```
Starting migration...
Resolving migrations. This may take 2 minutes ...
node:internal/modules/esm/load:208
    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed, schemes);
          ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:208:11)
    at defaultLoad (node:internal/modules/esm/load:103:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:819:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:590:43)
    at #createModuleJob (node:internal/modules/esm/loader:615:36)
    at #getJobFromResolveResult (node:internal/modules/esm/loader:343:34)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:308:41)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:657:25) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}

Node.js v24.1.0
```

**Problem:**
Dynamic imports of migration files on Windows used local file paths (e.g., `C:\...`), causing ESM loading errors (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) and TypeScript type errors (import specifier must be a string).

**Solution:**
1. Convert local file paths to `file://` protocol URLs using `pathToFileURL`.
2. Use the `.href` property of the URL object to get the string format, ensuring compatibility with ESM module loading and TypeScript type requirements.